### PR TITLE
fix: findUniqueOrThrowをfindFirstに変更

### DIFF
--- a/backend/src/deck/deck.service.ts
+++ b/backend/src/deck/deck.service.ts
@@ -75,7 +75,7 @@ export class DeckService {
    * deckIdでDeckを検索する。deckIdはバリデーションされている前提
    */
   async getDeckById(userId: string, deckId: bigint) {
-    return await this.prismaService.deck.findUniqueOrThrow({
+    return await this.prismaService.deck.findFirst({
       where: { userId: userId, id: deckId },
     });
   }


### PR DESCRIPTION
毎度おなじみfindUniqueでPK, Uniqueでない値をwhereに入れるミスを修正

OrThrowにした理由は覚えていないが、無意味なのでfindFirstに変更