### PR TITLE
feat: UserスキーマにrefreshTokenを追加

### DIFF
--- a/backend/prisma/migrations/20260407122913_add_refresh_token/migration.sql
+++ b/backend/prisma/migrations/20260407122913_add_refresh_token/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "refreshTokenExpiresAt" TIMESTAMP(3),
+ADD COLUMN     "refreshTokenHash" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -16,15 +16,17 @@ datasource db {
 
 // Userテーブル
 model User {
-  id           String   @id @default(uuid())
-  username     String   @unique
-  email        String?  @unique //Null許容
-  passwordHash String
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
-  decks        Deck[]
+  id                    String    @id @default(uuid())
+  username              String    @unique
+  email                 String?   @unique
+  passwordHash          String
+  refreshTokenHash      String?
+  refreshTokenExpiresAt DateTime? // refreshToken有効期限
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
+  decks                 Deck[]
 
-  @@map("users") // テーブル名をスネークケースにする
+  @@map("users")
 }
 
 // Deckテーブル


### PR DESCRIPTION
## 概要
refreshToken機能は大きめの機能なので、

- スキーマ
- サービス
- コントローラ
- 試験

の順でpr分割して行う。

## 説明
選択肢として、新たにrefreshtoken用のテーブルを作るか、Userテーブルにカラムを追加するかという二択があった。
userテーブルに追加する方法をとると、異なるデバイス間（PCとスマホなど）でrefreshTokenが異なり、セッションの維持ができないという問題がある。
今回のシステムの対象はPCのみなのでスマホなどの別デバイスの操作は考慮しないことにした。ただし同一ブラウザでの複数タブなどの複数ワーカーの対策はするつもりだ。

この判断は、のちにADRとして残しておく。

---
### 蛇足
今回、gitの操作で実装以上に時間をかけている。
元のpushは、変更が500行にもなりRVが困難なPRだった。
コードを書くとき前にしっかり工程を考えて、最初から意味のある変更ごとにprを出すべきだった。
この過程でスタックＰＲの方法などを学んだが、やったことはローカルをreset softして、remoteの履歴を強制書き換えすることだ。一人のブランチならこれが最適だと判断した。
複数人のブランチでやるとほかの人に迷惑がかかるのでやらない。
