### PR TITLE
Feat/add prisma and jwt filter

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -151,16 +151,8 @@ export class AuthService {
    */
   async refresh(refreshToken: string) {
     // トークンのデコード(認証と期限確認)
-    let payload: JwtPayload;
-    //
-    // trycatchを一時的に実装しているが、ブランチ終了後にfilterに実装を移動する。
-    //
-    try {
-      payload = await this.jwtService.verifyAsync<JwtPayload>(refreshToken); // jsonで返るのでinterface(typeでも可)で定義
-    } catch {
-      // 不正なjwtのときに投げられるJsonWebTokenError等を401に変換
-      throw new UnauthorizedException();
-    }
+    // 不正なjwtのときJsonWebTokenError, 期限切れのときはTokenExpiredError
+    const payload = await this.jwtService.verifyAsync<JwtPayload>(refreshToken); // jsonで返るのでinterface(typeでも可)で定義
     if (!payload || !payload.sub) throw new UnauthorizedException();
 
     // userが存在しない、またはRTとその期限が存在しないときはエラー

--- a/backend/src/common/filters/global.exception.filter.ts
+++ b/backend/src/common/filters/global.exception.filter.ts
@@ -10,6 +10,8 @@ import { Request, Response } from 'express';
 import { LoginFailedException } from '../exceptions/domain.exceptions';
 import { ValidationFailedException } from '../exceptions/application.exceptions';
 import { Prisma } from '@prisma/client';
+import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
+
 @Catch()
 export class GlobalExceptionFilter implements ExceptionFilter {
   // （時間があればWinstonやPinoで出力したい）
@@ -62,6 +64,32 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       return response.status(exception.getStatus()).json({
         statusCode: exception.getStatus(),
         message: exception.message,
+        timestamp: new Date().toISOString(),
+        path: request.url,
+      });
+
+      /*
+        JWT関連エラー
+      */
+      // JWTの期限切れ
+    } else if (exception instanceof TokenExpiredError) {
+      this.logger.warn(
+        `JWT Expired:${exception.message} - Path: ${request.url}`,
+      );
+      return response.status(HttpStatus.UNAUTHORIZED).json({
+        statusCode: HttpStatus.UNAUTHORIZED,
+        message: 'JWT Expired',
+        timestamp: new Date().toISOString(),
+        path: request.url,
+      });
+      // 不正なJWT
+    } else if (exception instanceof JsonWebTokenError) {
+      this.logger.warn(
+        `Invalid JWT:${exception.message} - Path: ${request.url}`,
+      );
+      return response.status(HttpStatus.UNAUTHORIZED).json({
+        statusCode: HttpStatus.UNAUTHORIZED,
+        message: 'Invalid JWT',
         timestamp: new Date().toISOString(),
         path: request.url,
       });

--- a/backend/src/common/filters/global.exception.filter.ts
+++ b/backend/src/common/filters/global.exception.filter.ts
@@ -9,7 +9,7 @@ import {
 import { Request, Response } from 'express';
 import { LoginFailedException } from '../exceptions/domain.exceptions';
 import { ValidationFailedException } from '../exceptions/application.exceptions';
-
+import { Prisma } from '@prisma/client';
 @Catch()
 export class GlobalExceptionFilter implements ExceptionFilter {
   // （時間があればWinstonやPinoで出力したい）
@@ -62,6 +62,42 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       return response.status(exception.getStatus()).json({
         statusCode: exception.getStatus(),
         message: exception.message,
+        timestamp: new Date().toISOString(),
+        path: request.url,
+      });
+
+      /*
+        prisma関連エラー
+      */
+    } else if (exception instanceof Prisma.PrismaClientKnownRequestError) {
+      this.logger.warn(
+        `Prisma Known Error [${exception.code}] - Path: ${request.url}`,
+      );
+
+      let status = HttpStatus.INTERNAL_SERVER_ERROR;
+      let message = 'Database Error';
+
+      // プロパティ―コードで分岐
+      switch (exception.code) {
+        case 'P2002': // 一意制約違反
+          status = HttpStatus.CONFLICT;
+          message = 'Duplicate field value';
+          break;
+        case 'P2003': // FK制約違反
+          status = HttpStatus.BAD_REQUEST;
+          message = 'Foreign Key not found';
+          break;
+        case 'P2025': // レコード未検出
+          status = HttpStatus.NOT_FOUND;
+          message = 'Record not found';
+          break;
+        default:
+          // その他は500で処理
+          break;
+      }
+      return response.status(status).json({
+        statusCode: status,
+        message: message,
         timestamp: new Date().toISOString(),
         path: request.url,
       });


### PR DESCRIPTION
### filterにprismaとjwt関連のハンドラを作成した

prismaには、KnownError以外にもUnknownErrorやConnectionErrorなどがあるが、KnownErrorのみをハンドルする最低限の実装を行った。ほかはすべて500で処理。

jwt関連では、verifyから発生する二つのエラーをキャッチしている。

prismaもjwtも同様に、フロントに渡す値は内部構造を隠ぺいするために抽象的な値にしている。