### PR TITLE
Feat/refator backend as using zod

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -85,8 +85,8 @@ jobs:
       # distが存在しないとbackendの型解決・ビルドが失敗する。
       # 依存関係インストール後、他のステップより先にビルドする必要がある。
       # ------------------------------------------------------------
-      #- name: Build shared package
-      #  run: npm run build --workspace=@memo-anki/shared
+      - name: Build shared package
+        run: npm run build --workspace=@memo-anki/shared
 
       # ------------------------------------------------------------
       # Prisma初期化
@@ -131,8 +131,8 @@ jobs:
       #
       # 【変更】working-directory から --workspace フラグに統一。
       # ------------------------------------------------------------
-      #- name: Build
-      #  run: npm run build --workspace=backend
+      - name: Build
+        run: npm run build --workspace=backend
 
       # ------------------------------------------------------------
       # ユニットテスト
@@ -143,5 +143,5 @@ jobs:
       #
       # 【変更】working-directory から --workspace フラグに統一。
       # ------------------------------------------------------------
-      #- name: Test
-      #  run: npm test --workspace=backend
+      - name: Test
+        run: npm test --workspace=backend

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -66,8 +66,8 @@ jobs:
       # あらかじめビルド可能な状態にしておくことで、shared変更時の
       # 影響検知を早期化できる。
       # ------------------------------------------------------------
-      #- name: Build shared package
-      #  run: npm run build --workspace=@memo-anki/shared
+      - name: Build shared package
+        run: npm run build --workspace=@memo-anki/shared
 
       # ------------------------------------------------------------
       # Prettierフォーマットチェック

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -7,12 +7,15 @@ import {
   Res,
   Req,
   UnauthorizedException,
+  UsePipes,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthResponse } from './dto/auth.response';
-import { LoginRequest } from './dto/login.request';
-import { RegisterRequest } from './dto/register.request';
 import express from 'express';
+
+// Zodスキーマをインポート
+import { LoginRequestSchema, RegisterRequestSchema } from '@memo-anki/shared';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 
 // 時間があればusername, passwordの変更削除機能を追加する
 @Controller('/auth')
@@ -20,11 +23,13 @@ export class AuthController {
   constructor(private authService: AuthService) {}
 
   @Post('register')
+  @UsePipes(new ZodValidationPipe(RegisterRequestSchema))
   async register(
-    @Body() request: RegisterRequest,
+    @Body() body: unknown,
     @Res({ passthrough: true }) res: express.Response,
   ) {
-    const result = await this.authService.register(request);
+    const validated = RegisterRequestSchema.parse(body);
+    const result = await this.authService.register(validated);
 
     // リフレッシュトークンをCookieに隠す
     this.setRefreshTokenCookie(res, result.tokens.refreshToken);
@@ -38,11 +43,13 @@ export class AuthController {
 
   @Post('login')
   @HttpCode(HttpStatus.OK)
+  @UsePipes(new ZodValidationPipe(LoginRequestSchema))
   async login(
-    @Body() request: LoginRequest,
+    @Body() body: unknown,
     @Res({ passthrough: true }) res: express.Response,
   ) {
-    const result = await this.authService.login(request);
+    const validated = LoginRequestSchema.parse(body);
+    const result = await this.authService.login(validated);
 
     // リフレッシュトークンをCookieに隠す
     this.setRefreshTokenCookie(res, result.tokens.refreshToken);

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -6,15 +6,15 @@ import {
 } from '../user/user.service';
 import { User } from '@prisma/client';
 
-import { LoginRequest } from './dto/login.request';
 import * as bcrypt from 'bcrypt';
-import { RegisterRequest } from './dto/register.request';
+
 import { JwtService } from '@nestjs/jwt';
 import {
   LoginFailedException,
   UserEmailAlreadyExistException,
   UsernameAlreadyExistException,
 } from '../common/exceptions/domain.exceptions';
+import { RegisterRequest, LoginRequest } from '@memo-anki/shared';
 
 interface JwtPayload {
   sub: string; // userId

--- a/backend/src/common/exceptions/application.exceptions.ts
+++ b/backend/src/common/exceptions/application.exceptions.ts
@@ -1,5 +1,6 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { ValidationError } from 'class-validator';
+import { ZodError } from 'zod';
 
 /**
  * 抽象アプリケーション例外 継承させて使用する
@@ -16,6 +17,15 @@ export abstract class ApplicationException extends HttpException {
  */
 export class ValidationFailedException extends ApplicationException {
   constructor(public readonly validationErrors: ValidationError[]) {
+    super('Validation Failed.', HttpStatus.BAD_REQUEST);
+  }
+}
+
+/**
+ * Validation系 (Zod用)
+ */
+export class ZodValidationException extends ApplicationException {
+  constructor(public readonly zodError: ZodError) {
     super('Validation Failed.', HttpStatus.BAD_REQUEST);
   }
 }

--- a/backend/src/common/filters/global.exception.filter.ts
+++ b/backend/src/common/filters/global.exception.filter.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { LoginFailedException } from '../exceptions/domain.exceptions';
-import { ValidationFailedException } from '../exceptions/application.exceptions';
+import { ZodValidationException } from '../exceptions/application.exceptions';
 import { Prisma } from '@prisma/client';
 import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
 
@@ -25,13 +25,13 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     /*
       validation例外（pipeでthrow）
     */
-    if (exception instanceof ValidationFailedException) {
+    if (exception instanceof ZodValidationException) {
       this.logger.warn(`${exception.message} - Path: ${request.url}`);
 
-      // Json例） "errors":[{password: '8文字以上で入力してください'}, ... ,{...}]
-      const details = exception.validationErrors.map((err) => ({
-        field: err.property,
-        message: Object.values(err.constraints || {})[0],
+      // ZodErrorを整形
+      const details = exception.zodError.errors.map((err) => ({
+        field: err.path.join('.'),
+        message: err.message,
       }));
 
       return response.status(HttpStatus.BAD_REQUEST).json({

--- a/backend/src/common/pipes/zod-validation.pipe.ts
+++ b/backend/src/common/pipes/zod-validation.pipe.ts
@@ -1,0 +1,19 @@
+import { PipeTransform, Injectable } from '@nestjs/common';
+import { ZodSchema, ZodError } from 'zod';
+import { ZodValidationException } from '../exceptions/application.exceptions';
+
+@Injectable()
+export class ZodValidationPipe implements PipeTransform {
+  constructor(private schema: ZodSchema) {}
+
+  transform(value: unknown) {
+    try {
+      return this.schema.parse(value);
+    } catch (error) {
+      if (error instanceof ZodError) {
+        throw new ZodValidationException(error);
+      }
+      throw error;
+    }
+  }
+}

--- a/backend/src/deck/deck.controller.ts
+++ b/backend/src/deck/deck.controller.ts
@@ -8,14 +8,21 @@ import {
   Post,
   Put,
   UseGuards,
+  UsePipes,
 } from '@nestjs/common';
+import {
+  CreateDeckRequest,
+  CreateDeckRequestSchema,
+  UpdateDeckRequest,
+  UpdateDeckRequestSchema,
+  RequiredDeckIdRequest,
+  RequiredDeckIdRequestSchema,
+} from '@memo-anki/shared';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import { DeckService } from './deck.service';
-import { CreateDeckRequest } from './dto/create-deck.request';
 import { JwtAuthGuard } from '../auth/jwt.guard';
 import { GetUserId } from '../common/decorators/get-userid.decorator';
-import { UpdateDeckRequest } from './dto/update-deck.request';
 import { DeckResponse } from './dto/deck.response';
-import { RequiredDeckIdRequest } from './dto/required-deckid.request';
 
 @Controller('deck')
 export class DeckController {
@@ -23,6 +30,7 @@ export class DeckController {
 
   @UseGuards(JwtAuthGuard)
   @Post()
+  @UsePipes(new ZodValidationPipe(CreateDeckRequestSchema))
   async createDeck(
     @GetUserId() userId: string,
     @Body() request: CreateDeckRequest,
@@ -40,6 +48,7 @@ export class DeckController {
 
   @UseGuards(JwtAuthGuard)
   @Put()
+  @UsePipes(new ZodValidationPipe(UpdateDeckRequestSchema))
   async updateDeck(
     @GetUserId() userId: string,
     @Body() request: UpdateDeckRequest,
@@ -51,6 +60,7 @@ export class DeckController {
   @UseGuards(JwtAuthGuard)
   @Delete()
   @HttpCode(HttpStatus.NO_CONTENT)
+  @UsePipes(new ZodValidationPipe(RequiredDeckIdRequestSchema))
   async deleteDeck(
     @GetUserId() userId: string,
     @Body() request: RequiredDeckIdRequest,

--- a/backend/src/deck/deck.service.ts
+++ b/backend/src/deck/deck.service.ts
@@ -1,13 +1,15 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '.././prisma/prisma.service';
-import { CreateDeckRequest } from './dto/create-deck.request';
 import { Deck, Prisma } from '@prisma/client';
-import { UpdateDeckRequest } from './dto/update-deck.request';
 import {
   DecknameAlreadyExistException,
   DeckNotFoundException,
 } from '../common/exceptions/domain.exceptions';
-import { RequiredDeckIdRequest } from './dto/required-deckid.request';
+import {
+  CreateDeckRequest,
+  UpdateDeckRequest,
+  RequiredDeckIdRequest,
+} from '@memo-anki/shared';
 
 // 将来的にserviceの引数をtype or interfaceに変更する可能性がある
 // このmodule以外、特にnotion連携機能で使う可能性がある。

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,17 +1,15 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { customValidationPipe } from './common/pipes/validation.pipe';
 import { GlobalExceptionFilter } from './common/filters/global.exception.filter';
 import cookieParser from 'cookie-parser';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  // バリデーション
-  app.useGlobalPipes(customValidationPipe);
-
-  //filter
+  // グローバルフィルター
   app.useGlobalFilters(new GlobalExceptionFilter());
+
+  // pipesは個別でつける設定に変更
 
   // CORS
   app.enableCors({

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -21,5 +21,7 @@
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false,
     "strictPropertyInitialization": false
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,0 +1,3 @@
+export * from './schemas/common';
+export * from './schemas/auth.schema';
+export * from './schemas/deck.schema';

--- a/shared/src/schemas/auth.schema.ts
+++ b/shared/src/schemas/auth.schema.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+import { notBlankString } from './common';
+
+// ========================================
+// リクエストスキーマ
+// ========================================
+
+export const RegisterRequestSchema = z
+  .object({
+    username: notBlankString('ユーザ名').max(
+      30,
+      '30文字以内で入力してください',
+    ),
+
+    password: notBlankString('パスワード')
+      .min(8, '8文字以上で入力してください')
+      .max(64, '64文字未満で入力してください'),
+
+    email: z
+      .string()
+      .email('有効なメールアドレスを入力してください')
+      .max(255, '255文字以内で入力してください')
+      .optional(),
+  })
+  .strict(); // ← 未定義のプロパティを拒否
+
+export const LoginRequestSchema = z
+  .object({
+    username: notBlankString('ユーザ名').max(
+      30,
+      '30文字以内で入力してください',
+    ),
+    password: notBlankString('パスワード').max(
+      64,
+      '64文字未満で入力してください',
+    ),
+  })
+  .strict(); // ← 未定義のプロパティを拒否
+
+// ========================================
+// レスポンススキーマ
+// ========================================
+
+export const AuthResponseSchema = z.object({
+  username: z.string(),
+  email: z.string().optional(),
+  accessToken: z.string(),
+});
+
+// ========================================
+// TypeScript型のエクスポート
+// ========================================
+
+export type RegisterRequest = z.infer<typeof RegisterRequestSchema>;
+export type LoginRequest = z.infer<typeof LoginRequestSchema>;
+export type AuthResponse = z.infer<typeof AuthResponseSchema>;

--- a/shared/src/schemas/common.ts
+++ b/shared/src/schemas/common.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+/**
+ * 空白のみを拒否する文字列スキーマ。
+ * trim後に1文字以上、max文字以下であることを保証する。
+ * trim済みの値に変換されるため、DB保存時も前後の空白は除去される。
+ *
+ * @param max 最大文字数
+ */
+export const notBlankString = (fieldName: string) =>
+  z
+    .string({ required_error: `${fieldName}は必須です` })
+    .trim()
+    .min(1, `${fieldName}を入力してください`);

--- a/shared/src/schemas/deck.schema.ts
+++ b/shared/src/schemas/deck.schema.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import { notBlankString } from './common';
+
+const deckIdSchema = z
+  .string()
+  .min(1)
+  .max(19)
+  .regex(/^-?\d+(\.\d+)?$/);
+
+export const CreateDeckRequestSchema = z
+  .object({
+    name: notBlankString('デッキ名').max(50, '50文字以内で入力してください'),
+    description: notBlankString('説明文')
+      .max(5000, '5000文字以内で入力してください')
+      .optional(),
+  })
+  .strict();
+
+export const UpdateDeckRequestSchema = z
+  .object({
+    deckId: deckIdSchema,
+    name: notBlankString('デッキ名').max(50, '50文字以内で入力してください'),
+    description: notBlankString('説明文')
+      .max(5000, '5000文字以内で入力してください')
+      .optional(),
+  })
+  .strict();
+
+export const RequiredDeckIdRequestSchema = z
+  .object({
+    deckId: deckIdSchema,
+  })
+  .strict();
+
+export const DeckResponseSchema = z.object({
+  id: z.bigint().transform((v) => v.toString()),
+  name: z.string(),
+  description: z
+    .string()
+    .nullable()
+    .transform((v) => v ?? undefined),
+  createdAt: z.date().transform((v) => v.toISOString()),
+});
+
+export type CreateDeckRequest = z.infer<typeof CreateDeckRequestSchema>;
+export type UpdateDeckRequest = z.infer<typeof UpdateDeckRequestSchema>;
+export type RequiredDeckIdRequest = z.infer<typeof RequiredDeckIdRequestSchema>;


### PR DESCRIPTION
zod導入を断念。変更コストが大きすぎる上に、説明ができない状態になった。
swaggerで型共有してバリデーション共有は諦める。

いったんfeat/zodに入れて、fea/zodブランチは存続させて、mainから別ブランチを本命として伸ばす。