### PR TITLE
Feat/deck screen api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ npm-debug.log*
 
 # node_modules
 node_modules/
+
+# claude
+CLAUDE.md

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,13 +10,13 @@ import { ConfigModule } from '@nestjs/config';
 
 @Module({
   imports: [
+    // vercelでは管理画面で設定した値が自動的にprocess.envに読み込まれる
+    ConfigModule.forRoot({ isGlobal: true, envFilePath: '.env' }), // 確実に.envを読み込ませる
     PrismaModule,
     UserModule,
     AuthModule,
     DeckModule,
     CardModule,
-    // vercelでは管理画面で設定した値が自動的にprocess.envに読み込まれる
-    ConfigModule.forRoot({ isGlobal: true, envFilePath: '.env' }), // 確実に.envを読み込ませる
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';

--- a/frontend/app/(main)/decks/page.tsx
+++ b/frontend/app/(main)/decks/page.tsx
@@ -1,43 +1,46 @@
 'use client';
 
+import { useDeckMutations } from '@/features/deck/hooks/useDeckMutations';
 import DeckGrid from '../../../features/deck/components/DeckGrid';
-import { components } from '@memo-anki/shared';
-type Deck = components['schemas']['DeckResponse'];
+import { useDecks } from '@/features/deck/hooks/useDecks';
 
-// 仮のデッキデータ（後でAPI fetchに置き換える）
-const dummyDecks: Deck[] = [
-  {
-    id: '1',
-    name: '基本情報技術者試験',
-    description: '午前問題の確認用デッキ',
-    createdAt: '2025-05-01',
-  },
-  {
-    id: '2',
-    name: 'TypeScript / Next.js',
-    description: 'フロントエンド技術の復習',
-    createdAt: '2025-05-01',
-  },
-  { id: '3', name: '英単語', description: '', createdAt: '2025-05-01' },
-  { id: '4', name: '英単語1', description: '', createdAt: '2025-05-01' },
-  { id: '5', name: '英単語2', description: '', createdAt: '2025-05-01' },
-];
+import { components } from '@memo-anki/shared';
+import { useState } from 'react';
+import DeckCreateModal from '@/features/deck/components/DeckCreateModal';
+type CreateDeckRequest = components['schemas']['CreateDeckRequest'];
 
 export default function DeckListPage() {
-  // 各ボタンの動き。まずは console.log だけ。
-  // 後でAPI 呼び出しに置き換え。
-  const handleReview = (deckId: string) => {
-    console.log('復習:', deckId);
+  // tanstackquery
+  const { createDeck, deleteDeck } = useDeckMutations();
+  const { data: decks, isLoading, isError, error } = useDecks();
+
+  // useState
+  const [open, setOpen] = useState(false);
+  const openModal = () => {
+    setOpen(true);
   };
-  const handleEdit = (deckId: string) => {
-    console.log('編集:', deckId);
+  const closeModal = () => {
+    setOpen(false);
+  };
+  // CRUD(可読性のためにラップしている)
+  // 以下二つはのちにlinkをつける
+  const handleReview = () => {
+    console.log('復習:link');
+  };
+  const handleEdit = () => {
+    console.log('編集:link');
   };
   const handleDelete = (deckId: string) => {
-    console.log('削除:', deckId);
+    deleteDeck.mutate(deckId);
   };
-  const handleCreate = () => {
-    console.log('新規作成');
+  const handleCreate = (data: CreateDeckRequest) => {
+    createDeck.mutate(data);
   };
+
+  // 例外処理をしないとdataがdeck[]として型認識されない
+  if (isLoading) return <div>読み込み中...</div>;
+  if (isError)
+    return <div>エラーが発生しました: {(error as Error).message}</div>;
 
   return (
     <div className="flex-1 flex flex-col bg-white text-gray-800">
@@ -49,10 +52,10 @@ export default function DeckListPage() {
             {/* タイトル + ボタンを横並びに */}
             <div className="flex items-center justify-between mb-5">
               <h1 className="text-[20px] font-bold">デッキ一覧</h1>
-
-              {/* 将来的に分離？ */}
               <button
-                onClick={() => handleCreate()} //onclickには関数だけ
+                onClick={() => {
+                  openModal();
+                }}
                 className="mt-4 w-25 h-9 rounded-md bg-indigo-600 hover:bg-indigo-800 text-white text-sm font-semibold"
               >
                 ＋ 新規作成
@@ -62,13 +65,18 @@ export default function DeckListPage() {
             <div className="border-t-[1px] border-gray-200 mb-8"></div>
 
             <DeckGrid
-              decks={dummyDecks}
+              decks={decks ?? []}
               onReview={handleReview}
               onEdit={handleEdit}
               onDelete={handleDelete}
             />
           </section>
         </div>
+        <DeckCreateModal
+          open={open}
+          onClose={closeModal}
+          onCreate={handleCreate}
+        />
       </main>
     </div>
   );

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { Toaster } from 'sonner';
 
 // client側の全体の設定
 // ブラウザにあるuserContextのようなもの、client側なのでuseClientを明記
@@ -11,6 +12,9 @@ export default function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <Toaster position="bottom-right" />
+    </QueryClientProvider>
   );
 }

--- a/frontend/features/deck/components/DeckCard.tsx
+++ b/frontend/features/deck/components/DeckCard.tsx
@@ -23,7 +23,7 @@ export default function DeckCard({
       </h2>
 
       {/* 説明文 */}
-      <p className="mt-2 text-[12.5px] text-gray-500 leading-snug">
+      <p className="mt-2 text-[12.5px] text-gray-500 leading-snug break-words">
         {deck.description || '説明はありません'}
       </p>
 

--- a/frontend/features/deck/components/DeckCreateModal.tsx
+++ b/frontend/features/deck/components/DeckCreateModal.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { components } from '@memo-anki/shared';
+
+type CreateDeckRequest = components['schemas']['CreateDeckRequest'];
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (deck: CreateDeckRequest) => void;
+};
+
+// バッファー（そのままREQUESTを使わない）
+type FormValues = {
+  name: string;
+  description: string;
+};
+
+export default function DeckCreateModal({ open, onClose, onCreate }: Props) {
+  // RHFのテンプレ
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({ defaultValues: { name: '', description: '' } });
+
+  // RHFは一番上でないといけないのでescapeをその下に配置
+  if (!open) return null;
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  // submitをトリガーとしてバリデーション後に関数実行
+  // そのための実行関数
+  const onSubmit = (data: FormValues) => {
+    onCreate({
+      name: data.name.trim(),
+      description: data.description.trim() || undefined,
+    });
+    reset();
+    onClose();
+  };
+
+  return (
+    /* 背景 */
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-4"
+      onClick={handleClose}
+    >
+      {/* モーダル（モーダル内は伝搬を止める） */}
+      <div
+        className="bg-white rounded-xl shadow-2xl w-full max-w-[440px] overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-6 pt-5 pb-3 border-b border-gray-200">
+          <h2 className="text-[16px] font-bold text-gray-900">
+            デッキを新規作成
+          </h2>
+        </div>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="px-6 py-5">
+          <div className="mb-4">
+            <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+              デッキ名 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              autoFocus
+              {...register('name', {
+                required: 'デッキ名は必須です',
+                maxLength: {
+                  value: 50,
+                  message: '50文字以内で入力してください',
+                },
+              })}
+              placeholder="例: 基本情報技術者試験"
+              className="input input-bordered w-full"
+            />
+            {errors.name && (
+              <p className="text-red-500 text-[12px] mt-1">
+                {errors.name.message}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+              説明
+            </label>
+            <textarea
+              {...register('description', {
+                maxLength: {
+                  // バックエンドは5000文字だが、フロントに合わせる。
+                  value: 200,
+                  message: '200文字以内で入力してください',
+                },
+              })}
+              placeholder="このデッキの内容や目的を簡単に書きます"
+              className="textarea textarea-bordered w-full min-h-[88px]"
+            />
+            {errors.description && (
+              <p className="text-red-500 text-[12px] mt-1">
+                {errors.description.message}
+              </p>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2 mt-6">
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={handleClose}
+            >
+              戻る
+            </button>
+            <button type="submit" className="btn btn-primary btn-sm">
+              作成
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/features/deck/hooks/useDeckMutations.ts
+++ b/frontend/features/deck/hooks/useDeckMutations.ts
@@ -1,0 +1,64 @@
+import { apiClient } from '@/lib/api/client';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { components } from '@memo-anki/shared';
+import { HttpStatus } from '@/lib/api/statusCodes';
+import { toast } from 'sonner';
+import { HttpError } from '@/lib/api/httpError';
+
+type CreateDeckRequest = components['schemas']['CreateDeckRequest'];
+type UpdateDeckRequest = components['schemas']['UpdateDeckRequest'];
+
+export const useDeckMutations = () => {
+  const queryClient = useQueryClient();
+
+  const handleSuccess = (action: string) => () => {
+    queryClient.invalidateQueries({ queryKey: ['decks'] });
+    toast.success(`${action}に成功しました`);
+  };
+
+  const handleError = (err: unknown) => {
+    if (err instanceof HttpError) {
+      switch (err.statusCode) {
+        case HttpStatus.BAD_REQUEST:
+          toast.error('正しい形式で入力してください');
+          break;
+        case HttpStatus.CONFLICT:
+          toast.error('同じ名前のデッキが既に存在します');
+          break;
+        case HttpStatus.NOT_FOUND:
+          toast.error('デッキが見つかりません');
+          break;
+        default:
+          toast.error('サーバーエラーが発生しました');
+      }
+    } else {
+      toast.error('ネットワークエラーが発生しました');
+    }
+  };
+
+  /** デッキ削除 Fetch */
+  const deleteDeck = useMutation({
+    mutationFn: (deckId: string) => apiClient(`/deck/${deckId}`, 'DELETE'),
+    onSuccess: handleSuccess('削除'),
+    onError: handleError,
+  });
+  /** デッキ作成 Fetch */
+  const createDeck = useMutation({
+    mutationFn: (data: CreateDeckRequest) => apiClient('/deck', 'POST', data),
+    onSuccess: handleSuccess('作成'),
+    onError: handleError,
+  });
+  /** デッキ更新 Fetch */
+  const updateDeck = useMutation({
+    mutationFn: ([deckId, body]: [string, UpdateDeckRequest]) =>
+      apiClient(`/deck/${deckId}`, 'PUT', body),
+    onSuccess: handleSuccess('更新'),
+    onError: handleError,
+  });
+
+  return {
+    deleteDeck,
+    createDeck,
+    updateDeck,
+  };
+};

--- a/frontend/features/deck/hooks/useDecks.ts
+++ b/frontend/features/deck/hooks/useDecks.ts
@@ -1,0 +1,12 @@
+import { apiClient } from '@/lib/api/client';
+import { useQuery } from '@tanstack/react-query';
+import { components } from '@memo-anki/shared';
+
+type Deck = components['schemas']['DeckResponse'];
+
+export const useDecks = () => {
+  return useQuery<Deck[]>({
+    queryKey: ['decks'],
+    queryFn: () => apiClient('/deck', 'GET') as Promise<Deck[]>,
+  });
+};

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -1,0 +1,29 @@
+import { HttpError } from './httpError';
+import { HttpStatus } from './statusCodes';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
+
+// fetchラッパー
+export async function apiClient(url: string, method: string, body?: unknown) {
+  // のちにメモリ（zustand）から取得？
+  const accessToken = '';
+
+  let res;
+  try {
+    res = await fetch(`${BASE_URL}${url}`, {
+      method,
+      credentials: 'include', // jwtをrequestに含める
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  } catch {
+    throw new Error('NetworkError');
+  }
+  if (!res.ok) throw new HttpError(res.status, 'Fetch Failed');
+
+  if (res.status === HttpStatus.NO_CONTENT) return null;
+  return res.json();
+}

--- a/frontend/lib/api/httpError.ts
+++ b/frontend/lib/api/httpError.ts
@@ -1,0 +1,7 @@
+export class HttpError extends Error {
+  statusCode: number;
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}

--- a/frontend/lib/api/statusCodes.ts
+++ b/frontend/lib/api/statusCodes.ts
@@ -1,0 +1,11 @@
+/**
+ * NestJSのstatusCodeのNext.jsバージョン
+ */
+export const HttpStatus = {
+  NO_CONTENT: 204,
+  BAD_REQUEST: 400,
+  CONFLICT: 409,
+  NOT_FOUND: 404,
+  UNAUTHORIZED: 401,
+  INTERNAL_SERVER_ERROR: 500,
+} as const;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-hook-form": "^7.72.1",
+    "sonner": "^2.0.7",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-hook-form": "^7.72.1",
+        "sonner": "^2.0.7",
         "zod": "^4.3.6",
         "zustand": "^5.0.12"
       },
@@ -14508,6 +14509,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {


### PR DESCRIPTION
api部分を作成
modal作成した。各モーダル共通のUI, 動作と固有の要素は分離することは今は行っていない。
deckの編集処理に関しては、linkでデッキ編集画面に移動して、そこでカードの編集とデッキの編集を行える仕様にしている。

バックエンドに影響するものとして、デッキのdescriptionを5000文字から200文字に変更することを決定した。
5000文字は必要ないうえにUIが不自然になるので200文字に制限することにした。

