### PR TITLE
Feat/card screen UI

### DIFF
--- a/frontend/app/(main)/decks/[deckId]/page.tsx
+++ b/frontend/app/(main)/decks/[deckId]/page.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useState } from 'react';
+import { useParams } from 'next/navigation';
+// import { useQueryClient } from '@tanstack/react-query';
+import { components } from '@memo-anki/shared';
+// import { useCards } from '@/features/card/hooks/useCards';
+// import { useCardMutations } from '@/features/card/hooks/useCardMutations';
+
+import CardListPageHeader from '@/features/card/components/CardListPageHeader';
+import CardList from '@/features/card/components/CardList';
+import CardCreateModal from '@/features/card/components/CardCreateModal';
+import CardEditModal from '@/features/card/components/CardEditModal';
+import DeckUpdateModal from '@/features/deck/components/DeckUpdateModal';
+
+type Card = components['schemas']['CardResponse'];
+type Deck = components['schemas']['DeckResponse'];
+
+const MOCK_DECK: Deck = {
+  id: '714',
+  name: 'test2',
+  description: 'lalalaa',
+  createdAt: '2026-04-28T14:23:39.477Z',
+};
+
+const MOCK_CARDS = [
+  {
+    id: '221',
+    deckId: '714',
+    name: 'OSI参照モデル',
+    type: 0,
+    content:
+      'OSI参照モデルは7層構造。第1層:物理層、第2層:データリンク層、第3層:ネットワーク層、第4層:トランスポート層、第5層:セッション層、第6層:プレゼンテーション層、第7層:アプリケーション層。',
+    question: null,
+    answer: null,
+    updatedAt: '2026-04-30T00:00:00.000Z',
+  },
+  {
+    id: '222',
+    deckId: '714',
+    name: 'TCP/IPの特徴',
+    type: 0,
+    content:
+      'TCPはコネクション型プロトコル。信頼性のあるデータ転送を保証する。UDPはコネクションレス型で高速だが信頼性は低い。',
+    question: null,
+    answer: null,
+    updatedAt: '2026-04-30T00:00:00.000Z',
+  },
+  {
+    id: '223',
+    deckId: '714',
+    name: 'IPアドレスクラス',
+    type: 1,
+    content: null,
+    question: 'クラスAのIPアドレスの先頭ビットは何か？',
+    answer: '0。範囲は 0.0.0.0 〜 127.255.255.255。',
+    updatedAt: '2026-04-30T00:00:00.000Z',
+  },
+  {
+    id: '224',
+    deckId: '714',
+    name: 'サブネットマスク',
+    type: 1,
+    content: null,
+    question: '/24 のサブネットマスクを10進数で表せ',
+    answer: '255.255.255.0',
+    updatedAt: '2026-04-30T00:00:00.000Z',
+  },
+] as unknown as Card[];
+
+export default function CardListPage() {
+  const params = useParams<{ deckId: string }>();
+  const deckId = params.deckId;
+
+  // const queryClient = useQueryClient();
+  // const deck = queryClient.getQueryData<Deck[]>(['decks'])?.find((d) => d.id === deckId);
+  // const { data: cards = [] } = useCards(deckId);
+  // const { deleteCard } = useCardMutations(deckId);
+  const deck = MOCK_DECK;
+  const cards = MOCK_CARDS;
+
+  const [openEditDeck, setOpenEditDeck] = useState(false);
+  const [openCreateCard, setOpenCreateCard] = useState(false);
+  const [editingCard, setEditingCard] = useState<Card | null>(null);
+
+  const handleEditCard = (cardId: string) => {
+    const target = cards.find((c) => c.id === cardId);
+    if (target) setEditingCard(target);
+  };
+  const handleDeleteCard = (cardId: string) => {
+    // deleteCard(cardId);
+    console.log('[stub] deleteCard', cardId);
+  };
+
+  return (
+    <main className="flex-1 bg-gray-50">
+      <div className="max-w-[1536px] mx-auto px-6 py-8">
+        <section className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+          <CardListPageHeader
+            deckName={deck?.name ?? ''}
+            onEditDeck={() => setOpenEditDeck(true)}
+            onAddCard={() => setOpenCreateCard(true)}
+          />
+          <CardList
+            cards={cards}
+            onEdit={handleEditCard}
+            onDelete={handleDeleteCard}
+          />
+        </section>
+      </div>
+
+      {/* デッキ編集モーダル */}
+      {deck && (
+        <DeckUpdateModal
+          open={openEditDeck}
+          onClose={() => setOpenEditDeck(false)}
+          initialDeck={deck}
+          onSave={(values) => {
+            console.log('[stub] updateDeck', deckId, values);
+          }}
+        />
+      )}
+
+      {/* カード作成モーダル */}
+      <CardCreateModal
+        open={openCreateCard}
+        onClose={() => setOpenCreateCard(false)}
+        onCreate={(values) => {
+          console.log('[stub] createCard', values);
+        }}
+      />
+
+      {/* カード編集モーダル */}
+      {editingCard && (
+        <CardEditModal
+          open={!!editingCard}
+          onClose={() => setEditingCard(null)}
+          initialCard={editingCard}
+          onSave={(values) => {
+            console.log('[stub] updateCard', editingCard.id, values);
+          }}
+        />
+      )}
+    </main>
+  );
+}

--- a/frontend/app/(main)/decks/page.tsx
+++ b/frontend/app/(main)/decks/page.tsx
@@ -3,6 +3,7 @@
 import { useDeckMutations } from '@/features/deck/hooks/useDeckMutations';
 import DeckGrid from '../../../features/deck/components/DeckGrid';
 import { useDecks } from '@/features/deck/hooks/useDecks';
+import { useRouter } from 'next/navigation';
 
 import { components } from '@memo-anki/shared';
 import { useState } from 'react';
@@ -10,25 +11,21 @@ import DeckCreateModal from '@/features/deck/components/DeckCreateModal';
 type CreateDeckRequest = components['schemas']['CreateDeckRequest'];
 
 export default function DeckListPage() {
+  //router
+  const router = useRouter();
   // tanstackquery
   const { createDeck, deleteDeck } = useDeckMutations();
   const { data: decks, isLoading, isError, error } = useDecks();
 
   // useState
   const [open, setOpen] = useState(false);
-  const openModal = () => {
-    setOpen(true);
-  };
-  const closeModal = () => {
-    setOpen(false);
-  };
+
   // CRUD(可読性のためにラップしている)
-  // 以下二つはのちにlinkをつける
   const handleReview = () => {
     console.log('復習:link');
   };
-  const handleEdit = () => {
-    console.log('編集:link');
+  const handleEdit = (deckId: string) => {
+    router.push(`/decks/${deckId}`);
   };
   const handleDelete = (deckId: string) => {
     deleteDeck.mutate(deckId);
@@ -54,7 +51,7 @@ export default function DeckListPage() {
               <h1 className="text-[20px] font-bold">デッキ一覧</h1>
               <button
                 onClick={() => {
-                  openModal();
+                  setOpen(true);
                 }}
                 className="mt-4 w-25 h-9 rounded-md bg-indigo-600 hover:bg-indigo-800 text-white text-sm font-semibold"
               >
@@ -74,7 +71,9 @@ export default function DeckListPage() {
         </div>
         <DeckCreateModal
           open={open}
-          onClose={closeModal}
+          onClose={() => {
+            setOpen(false);
+          }}
           onCreate={handleCreate}
         />
       </main>

--- a/frontend/features/card/components/CardCreateModal.tsx
+++ b/frontend/features/card/components/CardCreateModal.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+
+type FormValues = {
+  name: string;
+  description: string;
+};
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (data: FormValues) => void;
+};
+
+export default function CardCreateModal({ open, onClose, onCreate }: Props) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({ defaultValues: { name: '', description: '' } });
+
+  if (!open) return null;
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const onSubmit = (data: FormValues) => {
+    onCreate({
+      name: data.name.trim(),
+      description: data.description.trim(),
+    });
+    reset();
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-4"
+      onClick={handleClose}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl w-full max-w-[440px] overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-6 pt-5 pb-3 border-b border-gray-200">
+          <h2 className="text-[16px] font-bold text-gray-900">
+            カードを新規作成
+          </h2>
+        </div>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="px-6 py-5">
+          <div className="mb-4">
+            <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+              カード名 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              autoFocus
+              {...register('name', {
+                required: 'カード名は必須です',
+                maxLength: {
+                  value: 50,
+                  message: '50文字以内で入力してください',
+                },
+              })}
+              placeholder="例: 基本情報技術者試験 第1章"
+              className="input input-bordered w-full"
+            />
+            {errors.name && (
+              <p className="text-red-500 text-[12px] mt-1">
+                {errors.name.message}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+              内容
+            </label>
+            <textarea
+              {...register('description', {
+                maxLength: {
+                  value: 10000,
+                  message: '10000文字以内で入力してください',
+                },
+              })}
+              placeholder="カードの内容を入力してください"
+              className="textarea textarea-bordered w-full min-h-[88px]"
+            />
+            {errors.description && (
+              <p className="text-red-500 text-[12px] mt-1">
+                {errors.description.message}
+              </p>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2 mt-6">
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={handleClose}
+            >
+              戻る
+            </button>
+            <button type="submit" className="btn btn-primary btn-sm">
+              作成
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/features/card/components/CardEditModal.tsx
+++ b/frontend/features/card/components/CardEditModal.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { components } from '@memo-anki/shared';
+
+type Card = components['schemas']['CardResponse'];
+
+type FormValues = {
+  name: string;
+  description: string;
+};
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  initialCard: Card;
+  onSave: (data: FormValues) => void;
+};
+
+export default function CardEditModal({
+  open,
+  onClose,
+  initialCard,
+  onSave,
+}: Props) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues: {
+      name: initialCard.name,
+      description: String(initialCard.content ?? initialCard.question ?? ''),
+    },
+  });
+
+  if (!open) return null;
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const onSubmit = (data: FormValues) => {
+    onSave({
+      name: data.name.trim(),
+      description: data.description.trim(),
+    });
+    reset();
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-4"
+      onClick={handleClose}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl w-full max-w-[440px] overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-6 pt-5 pb-3 border-b border-gray-200">
+          <h2 className="text-[16px] font-bold text-gray-900">カードを編集</h2>
+        </div>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="px-6 py-5">
+          <div className="mb-4">
+            <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+              カード名 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              autoFocus
+              {...register('name', {
+                required: 'カード名は必須です',
+                maxLength: {
+                  value: 50,
+                  message: '50文字以内で入力してください',
+                },
+              })}
+              className="input input-bordered w-full"
+            />
+            {errors.name && (
+              <p className="text-red-500 text-[12px] mt-1">
+                {errors.name.message}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+              内容
+            </label>
+            <textarea
+              {...register('description', {
+                maxLength: {
+                  value: 10000,
+                  message: '10000文字以内で入力してください',
+                },
+              })}
+              className="textarea textarea-bordered w-full min-h-[88px]"
+            />
+            {errors.description && (
+              <p className="text-red-500 text-[12px] mt-1">
+                {errors.description.message}
+              </p>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2 mt-6">
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={handleClose}
+            >
+              戻る
+            </button>
+            <button type="submit" className="btn btn-primary btn-sm">
+              保存
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/features/card/components/CardList.tsx
+++ b/frontend/features/card/components/CardList.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { components } from '@memo-anki/shared';
+import CardRow from './CardRow';
+
+type Card = components['schemas']['CardResponse'];
+
+type CardListProps = {
+  cards: Card[];
+  onEdit: (cardId: string) => void;
+  onDelete: (cardId: string) => void;
+};
+
+export default function CardList({ cards, onEdit, onDelete }: CardListProps) {
+  return (
+    <>
+      {/* 列ラベル（md以上で詳細・日時列を表示） */}
+      <div
+        className="
+          grid gap-4
+          grid-cols-[1fr_auto] md:grid-cols-[1fr_2fr_auto_auto]
+          px-4 py-2
+          bg-gray-50
+          border-b-2 border-gray-200
+          text-[11.5px] font-semibold uppercase tracking-wider text-gray-500
+        "
+      >
+        <span>カード名 / タイプ</span>
+        <span className="hidden md:block">詳細</span>
+        <span className="hidden md:block">作成日時</span>
+        <span />
+      </div>
+
+      {/* 行 */}
+      <ul>
+        {cards.length === 0 ? (
+          <li className="px-4 py-10 text-center text-[13px] text-gray-400">
+            カードがまだありません
+          </li>
+        ) : (
+          cards.map((card) => (
+            <CardRow
+              key={card.id}
+              card={card}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
+          ))
+        )}
+      </ul>
+    </>
+  );
+}

--- a/frontend/features/card/components/CardListPageHeader.tsx
+++ b/frontend/features/card/components/CardListPageHeader.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import Link from 'next/link';
+
+type CardListPageHeaderProps = {
+  deckName: string;
+  onEditDeck: () => void;
+  onAddCard: () => void;
+};
+
+export default function CardListPageHeader({
+  deckName,
+  onEditDeck,
+  onAddCard,
+}: CardListPageHeaderProps) {
+  return (
+    <div className="flex items-center justify-between px-8 py-5 border-b border-gray-200">
+      {/* 左：パンくず + タイトル */}
+      <div>
+        <p className="text-[12px] text-gray-400 mb-0.5">
+          <Link href="/decks" className="hover:underline">
+            デッキ一覧
+          </Link>
+          <span className="mx-1">›</span>
+          <span className="text-gray-600 font-medium">{deckName}</span>
+        </p>
+        <h1 className="text-[20px] font-bold text-gray-900">カード一覧</h1>
+      </div>
+
+      {/* 右：デッキ編集 + カード追加 */}
+      <div className="flex items-center gap-2">
+        <button
+          onClick={onEditDeck}
+          className="btn btn-outline btn-primary btn-sm"
+        >
+          デッキ編集
+        </button>
+        <button onClick={onAddCard} className="btn btn-primary btn-sm">
+          ＋ カード追加
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/features/card/components/CardRow.tsx
+++ b/frontend/features/card/components/CardRow.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { components } from '@memo-anki/shared';
+import CardTypeBadge from './CardTypeBadge';
+import { buildCardDetail, formatDate } from '../utils/cardView';
+
+type Card = components['schemas']['CardResponse'];
+
+type CardRowProps = {
+  card: Card;
+  onEdit: (cardId: string) => void;
+  onDelete: (cardId: string) => void;
+};
+
+export default function CardRow({ card, onEdit, onDelete }: CardRowProps) {
+  const detail = buildCardDetail(card);
+  const date = formatDate(card.updatedAt);
+
+  return (
+    <li
+      className="
+        grid items-center gap-4
+        grid-cols-[1fr_auto] md:grid-cols-[1fr_2fr_auto_auto]
+        px-4 py-3
+        border-b border-gray-200 last:border-b-0
+        bg-white hover:bg-gray-50
+      "
+    >
+      {/* カード名 + タイプバッジ */}
+      <div className="flex flex-col gap-1 min-w-0">
+        <span className="text-[13.5px] font-semibold text-gray-900 truncate">
+          {card.name}
+        </span>
+        <CardTypeBadge type={card.type} />
+      </div>
+
+      {/* 詳細（md以上で表示） */}
+      <div className="hidden md:block text-[12.5px] text-gray-500 leading-snug truncate">
+        {detail}
+      </div>
+
+      {/* 日時（md以上で表示） */}
+      <div className="hidden md:block text-[12px] text-gray-400 whitespace-nowrap">
+        {date}
+      </div>
+
+      {/* ボタン */}
+      <div className="flex gap-2 shrink-0">
+        <button
+          onClick={() => onEdit(card.id)}
+          className="btn btn-outline btn-sm"
+        >
+          編集
+        </button>
+        <button
+          onClick={() => onDelete(card.id)}
+          className="btn btn-outline btn-error btn-sm font-bold"
+        >
+          削除
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/frontend/features/card/components/CardTypeBadge.tsx
+++ b/frontend/features/card/components/CardTypeBadge.tsx
@@ -1,0 +1,23 @@
+import { components } from '@memo-anki/shared';
+
+type CardType = components['schemas']['CardResponse']['type'];
+
+type CardTypeBadgeProps = {
+  type: CardType;
+};
+
+/** type によってNote, Quizを分岐してバッチを表示 */
+export default function CardTypeBadge({ type }: CardTypeBadgeProps) {
+  if (type === 0) {
+    return (
+      <span className="inline-block w-fit px-1.5 py-px rounded-full border border-blue-200 bg-blue-50 text-blue-500 text-[11px] font-semibold">
+        NOTE
+      </span>
+    );
+  }
+  return (
+    <span className="inline-block w-fit px-1.5 py-px rounded-full border border-fuchsia-200 bg-fuchsia-50 text-fuchsia-500 text-[11px] font-semibold">
+      QUIZ
+    </span>
+  );
+}

--- a/frontend/features/card/utils/cardView.ts
+++ b/frontend/features/card/utils/cardView.ts
@@ -1,0 +1,22 @@
+import { components } from '@memo-anki/shared';
+
+type Card = components['schemas']['CardResponse'];
+
+export function buildCardDetail(card: Card): string {
+  if (card.type === 0) return String(card.content ?? '');
+  const q = card.question ? `Q: ${String(card.question)}` : '';
+  const a = card.answer ? `A: ${String(card.answer)}` : '';
+  return [q, a].filter(Boolean).join('  '); // 空白を除去してq,a結合
+}
+// 単純なフォーマット utilsへ共有関数化するかも
+export function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}

--- a/frontend/features/deck/components/DeckUpdateModal.tsx
+++ b/frontend/features/deck/components/DeckUpdateModal.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { components } from '@memo-anki/shared';
+
+type DeckResponse = components['schemas']['DeckResponse'];
+type UpdateDeckRequest = components['schemas']['UpdateDeckRequest'];
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  initialDeck: DeckResponse;
+  onSave: (values: UpdateDeckRequest) => void;
+};
+
+type FormValues = {
+  name: string;
+  description: string;
+};
+/** CreateModalにカラム値初期設定しただけ */
+export default function DeckUpdateModal({
+  open,
+  onClose,
+  initialDeck,
+  onSave,
+}: Props) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>();
+
+  // 閉じるたびに編集対象のデッキ情報をフォームにセット
+  useEffect(() => {
+    if (open) {
+      reset({
+        name: initialDeck.name,
+        description: initialDeck.description ?? '',
+      });
+    }
+  }, [open, initialDeck, reset]);
+
+  if (!open) return null;
+
+  const onSubmit = (data: FormValues) => {
+    onSave({
+      name: data.name.trim(),
+      description: data.description.trim() || undefined,
+    });
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl w-full max-w-[440px] overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-6 pt-5 pb-3 border-b border-gray-200">
+          <h2 className="text-[16px] font-bold text-gray-900">デッキを編集</h2>
+        </div>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="px-6 py-5">
+          <div className="mb-4">
+            <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+              デッキ名 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              autoFocus
+              {...register('name', {
+                required: 'デッキ名は必須です',
+                maxLength: {
+                  value: 50,
+                  message: '50文字以内で入力してください',
+                },
+              })}
+              className="input input-bordered w-full"
+            />
+            {errors.name && (
+              <p className="text-red-500 text-[12px] mt-1">
+                {errors.name.message}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+              説明
+            </label>
+            <textarea
+              {...register('description', {
+                maxLength: {
+                  value: 200,
+                  message: '200文字以内で入力してください',
+                },
+              })}
+              className="textarea textarea-bordered w-full min-h-[88px]"
+            />
+            {errors.description && (
+              <p className="text-red-500 text-[12px] mt-1">
+                {errors.description.message}
+              </p>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2 mt-6">
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={onClose}
+            >
+              戻る
+            </button>
+            <button type="submit" className="btn btn-primary btn-sm">
+              保存
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
カード一覧画面のUIを作成した。
コード量は多いが、モーダルはDeckCreateModalのほぼコピペであり許容範囲。

一つのデッキにtypeが混在してもいいようにしている。ただし、updateではtypeを変更できないようにしている。そのためtypeを変えるには新しくカードを作ることを強制する。
モーダルのtypeによる入力分岐は未実装。

次にapiとの接続部分を行う。