### PR TITLE
Feat/card screen api

### DIFF
--- a/backend/src/card/dto/card.response.ts
+++ b/backend/src/card/dto/card.response.ts
@@ -14,13 +14,25 @@ export class CardResponse {
   @ApiProperty({ example: 0, description: '0=note, 1=quiz', enum: [0, 1] })
   type: number;
 
-  @ApiPropertyOptional({ example: 'Card content here', nullable: true })
+  @ApiPropertyOptional({
+    type: 'string',
+    example: 'Card content here',
+    nullable: true,
+  })
   content: string | null;
 
-  @ApiPropertyOptional({ example: 'What is ...?', nullable: true })
+  @ApiPropertyOptional({
+    type: 'string',
+    example: 'What is ...?',
+    nullable: true,
+  })
   question: string | null;
 
-  @ApiPropertyOptional({ example: 'The answer is ...', nullable: true })
+  @ApiPropertyOptional({
+    type: 'string',
+    example: 'The answer is ...',
+    nullable: true,
+  })
   answer: string | null;
 
   @ApiProperty({ example: '2024-01-01T00:00:00.000Z' })

--- a/backend/src/card/dto/create-card.request.ts
+++ b/backend/src/card/dto/create-card.request.ts
@@ -26,19 +26,31 @@ export class CreateCardRequest {
   @IsIn([0, 1])
   type: number;
 
-  @ApiPropertyOptional({ example: 'Card content here', maxLength: 10000 })
+  @ApiPropertyOptional({
+    type: 'string',
+    example: 'Card content here',
+    maxLength: 10000,
+  })
   @IsOptional()
   @IsString()
   @Length(1, 10000)
   content: string | undefined;
 
-  @ApiPropertyOptional({ example: 'What is ...?', maxLength: 5000 })
+  @ApiPropertyOptional({
+    type: 'string',
+    example: 'What is ...?',
+    maxLength: 5000,
+  })
   @IsOptional()
   @IsString()
   @Length(1, 5000)
   question: string | undefined;
 
-  @ApiPropertyOptional({ example: 'The answer is ...', maxLength: 5000 })
+  @ApiPropertyOptional({
+    type: 'string',
+    example: 'The answer is ...',
+    maxLength: 5000,
+  })
   @IsOptional()
   @IsString()
   @Length(1, 5000)

--- a/backend/src/card/dto/update-card.request.ts
+++ b/backend/src/card/dto/update-card.request.ts
@@ -10,19 +10,31 @@ export class UpdateCardRequest {
   @Length(1, 50)
   name: string;
 
-  @ApiPropertyOptional({ example: 'Updated content', maxLength: 10000 })
+  @ApiPropertyOptional({
+    type: 'string',
+    example: 'Updated content',
+    maxLength: 10000,
+  })
   @IsOptional()
   @IsString()
   @Length(1, 10000)
   content: string | undefined;
 
-  @ApiPropertyOptional({ example: 'Updated question?', maxLength: 5000 })
+  @ApiPropertyOptional({
+    type: 'string',
+    example: 'Updated question?',
+    maxLength: 5000,
+  })
   @IsOptional()
   @IsString()
   @Length(1, 5000)
   question: string | undefined;
 
-  @ApiPropertyOptional({ example: 'Updated answer', maxLength: 5000 })
+  @ApiPropertyOptional({
+    type: 'string',
+    example: 'Updated answer',
+    maxLength: 5000,
+  })
   @IsOptional()
   @IsString()
   @Length(1, 5000)

--- a/frontend/app/(main)/decks/[deckId]/page.tsx
+++ b/frontend/app/(main)/decks/[deckId]/page.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useState } from 'react';
+import { useParams } from 'next/navigation';
+// import { useQueryClient } from '@tanstack/react-query';
+import { components } from '@memo-anki/shared';
+// import { useCards } from '@/features/card/hooks/useCards';
+// import { useCardMutations } from '@/features/card/hooks/useCardMutations';
+
+import CardListPageHeader from '@/features/card/components/CardListPageHeader';
+import CardList from '@/features/card/components/CardList';
+import CardCreateModal from '@/features/card/components/CardCreateModal';
+import CardEditModal from '@/features/card/components/CardEditModal';
+import DeckUpdateModal from '@/features/deck/components/DeckUpdateModal';
+
+type Card = components['schemas']['CardResponse'];
+type Deck = components['schemas']['DeckResponse'];
+
+const MOCK_DECK: Deck = {
+  id: '714',
+  name: 'test2',
+  description: 'lalalaa',
+  createdAt: '2026-04-28T14:23:39.477Z',
+};
+
+const MOCK_CARDS = [
+  {
+    id: '221',
+    deckId: '714',
+    name: 'OSI参照モデル',
+    type: 0,
+    content:
+      'OSI参照モデルは7層構造。第1層:物理層、第2層:データリンク層、第3層:ネットワーク層、第4層:トランスポート層、第5層:セッション層、第6層:プレゼンテーション層、第7層:アプリケーション層。',
+    question: null,
+    answer: null,
+    updatedAt: '2026-04-30T00:00:00.000Z',
+  },
+  {
+    id: '222',
+    deckId: '714',
+    name: 'TCP/IPの特徴',
+    type: 0,
+    content:
+      'TCPはコネクション型プロトコル。信頼性のあるデータ転送を保証する。UDPはコネクションレス型で高速だが信頼性は低い。',
+    question: null,
+    answer: null,
+    updatedAt: '2026-04-30T00:00:00.000Z',
+  },
+  {
+    id: '223',
+    deckId: '714',
+    name: 'IPアドレスクラス',
+    type: 1,
+    content: null,
+    question: 'クラスAのIPアドレスの先頭ビットは何か？',
+    answer: '0。範囲は 0.0.0.0 〜 127.255.255.255。',
+    updatedAt: '2026-04-30T00:00:00.000Z',
+  },
+  {
+    id: '224',
+    deckId: '714',
+    name: 'サブネットマスク',
+    type: 1,
+    content: null,
+    question: '/24 のサブネットマスクを10進数で表せ',
+    answer: '255.255.255.0',
+    updatedAt: '2026-04-30T00:00:00.000Z',
+  },
+] as unknown as Card[];
+
+export default function CardListPage() {
+  const params = useParams<{ deckId: string }>();
+  const deckId = params.deckId;
+
+  // const queryClient = useQueryClient();
+  // const deck = queryClient.getQueryData<Deck[]>(['decks'])?.find((d) => d.id === deckId);
+  // const { data: cards = [] } = useCards(deckId);
+  // const { deleteCard } = useCardMutations(deckId);
+  const deck = MOCK_DECK;
+  const cards = MOCK_CARDS;
+
+  const [openEditDeck, setOpenEditDeck] = useState(false);
+  const [openCreateCard, setOpenCreateCard] = useState(false);
+  const [editingCard, setEditingCard] = useState<Card | null>(null);
+
+  const handleEditCard = (cardId: string) => {
+    const target = cards.find((c) => c.id === cardId);
+    if (target) setEditingCard(target);
+  };
+  const handleDeleteCard = (cardId: string) => {
+    // deleteCard(cardId);
+    console.log('[stub] deleteCard', cardId);
+  };
+
+  return (
+    <main className="flex-1 bg-gray-50">
+      <div className="max-w-[1536px] mx-auto px-6 py-8">
+        <section className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+          <CardListPageHeader
+            deckName={deck?.name ?? ''}
+            onEditDeck={() => setOpenEditDeck(true)}
+            onAddCard={() => setOpenCreateCard(true)}
+          />
+          <CardList
+            cards={cards}
+            onEdit={handleEditCard}
+            onDelete={handleDeleteCard}
+          />
+        </section>
+      </div>
+
+      {/* デッキ編集モーダル */}
+      {deck && (
+        <DeckUpdateModal
+          open={openEditDeck}
+          onClose={() => setOpenEditDeck(false)}
+          initialDeck={deck}
+          onSave={(values) => {
+            console.log('[stub] updateDeck', deckId, values);
+          }}
+        />
+      )}
+
+      {/* カード作成モーダル */}
+      <CardCreateModal
+        open={openCreateCard}
+        onClose={() => setOpenCreateCard(false)}
+        onCreate={(values) => {
+          console.log('[stub] createCard', values);
+        }}
+      />
+
+      {/* カード編集モーダル */}
+      {editingCard && (
+        <CardEditModal
+          open={!!editingCard}
+          onClose={() => setEditingCard(null)}
+          initialCard={editingCard}
+          onSave={(values) => {
+            console.log('[stub] updateCard', editingCard.id, values);
+          }}
+        />
+      )}
+    </main>
+  );
+}

--- a/frontend/app/(main)/decks/[deckId]/page.tsx
+++ b/frontend/app/(main)/decks/[deckId]/page.tsx
@@ -2,96 +2,73 @@
 
 import { useState } from 'react';
 import { useParams } from 'next/navigation';
-// import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { components } from '@memo-anki/shared';
-// import { useCards } from '@/features/card/hooks/useCards';
-// import { useCardMutations } from '@/features/card/hooks/useCardMutations';
+import { useCards } from '@/features/card/hooks/useCards';
+import { useCardMutations } from '@/features/card/hooks/useCardMutations';
 
 import CardListPageHeader from '@/features/card/components/CardListPageHeader';
 import CardList from '@/features/card/components/CardList';
 import CardCreateModal from '@/features/card/components/CardCreateModal';
 import CardEditModal from '@/features/card/components/CardEditModal';
 import DeckUpdateModal from '@/features/deck/components/DeckUpdateModal';
+import { useDeckMutations } from '@/features/deck/hooks/useDeckMutations';
 
 type Card = components['schemas']['CardResponse'];
+type CreateCardRequest = components['schemas']['CreateCardRequest'];
+type UpdateCardRequest = components['schemas']['UpdateCardRequest'];
 type Deck = components['schemas']['DeckResponse'];
-
-const MOCK_DECK: Deck = {
-  id: '714',
-  name: 'test2',
-  description: 'lalalaa',
-  createdAt: '2026-04-28T14:23:39.477Z',
-};
-
-const MOCK_CARDS = [
-  {
-    id: '221',
-    deckId: '714',
-    name: 'OSI参照モデル',
-    type: 0,
-    content:
-      'OSI参照モデルは7層構造。第1層:物理層、第2層:データリンク層、第3層:ネットワーク層、第4層:トランスポート層、第5層:セッション層、第6層:プレゼンテーション層、第7層:アプリケーション層。',
-    question: null,
-    answer: null,
-    updatedAt: '2026-04-30T00:00:00.000Z',
-  },
-  {
-    id: '222',
-    deckId: '714',
-    name: 'TCP/IPの特徴',
-    type: 0,
-    content:
-      'TCPはコネクション型プロトコル。信頼性のあるデータ転送を保証する。UDPはコネクションレス型で高速だが信頼性は低い。',
-    question: null,
-    answer: null,
-    updatedAt: '2026-04-30T00:00:00.000Z',
-  },
-  {
-    id: '223',
-    deckId: '714',
-    name: 'IPアドレスクラス',
-    type: 1,
-    content: null,
-    question: 'クラスAのIPアドレスの先頭ビットは何か？',
-    answer: '0。範囲は 0.0.0.0 〜 127.255.255.255。',
-    updatedAt: '2026-04-30T00:00:00.000Z',
-  },
-  {
-    id: '224',
-    deckId: '714',
-    name: 'サブネットマスク',
-    type: 1,
-    content: null,
-    question: '/24 のサブネットマスクを10進数で表せ',
-    answer: '255.255.255.0',
-    updatedAt: '2026-04-30T00:00:00.000Z',
-  },
-] as unknown as Card[];
+type UpdateDeckRequest = components['schemas']['UpdateDeckRequest'];
 
 export default function CardListPage() {
+  // urlからパスパラメータ取得
   const params = useParams<{ deckId: string }>();
   const deckId = params.deckId;
 
-  // const queryClient = useQueryClient();
-  // const deck = queryClient.getQueryData<Deck[]>(['decks'])?.find((d) => d.id === deckId);
-  // const { data: cards = [] } = useCards(deckId);
-  // const { deleteCard } = useCardMutations(deckId);
-  const deck = MOCK_DECK;
-  const cards = MOCK_CARDS;
+  // キャッシュからdeckを取得（fetchはせずキャッシュ更新を購読）
+  const queryClient = useQueryClient();
+  const { data: decks } = useQuery<Deck[]>({
+    queryKey: ['decks'],
+    queryFn: () =>
+      Promise.resolve(queryClient.getQueryData<Deck[]>(['decks']) ?? []),
+    enabled: false,
+  });
+  const deck = decks?.find((deck) => deck.id === deckId);
 
+  // tanstackquery
+  // cardsがundefinedのまま到達することはないが初期値[]で型を確定
+  const { data: cards = [], isLoading, isError, error } = useCards(deckId);
+  const { createCard, updateCard, deleteCard } = useCardMutations();
+  const { updateDeck } = useDeckMutations();
+
+  // useState（モーダル開閉）
   const [openEditDeck, setOpenEditDeck] = useState(false);
   const [openCreateCard, setOpenCreateCard] = useState(false);
   const [editingCard, setEditingCard] = useState<Card | null>(null);
 
+  // CRUD
+  //deck
+  const handleEditDeck = (deckId: string, body: UpdateDeckRequest) => {
+    updateDeck.mutate([deckId, body]);
+  };
+  //card
   const handleEditCard = (cardId: string) => {
     const target = cards.find((c) => c.id === cardId);
     if (target) setEditingCard(target);
   };
+  const handleCreateCard = (data: CreateCardRequest) => {
+    createCard.mutate(data);
+  };
+  const handleUpdateCard = (cardId: string, body: UpdateCardRequest) => {
+    updateCard.mutate([cardId, body]);
+  };
   const handleDeleteCard = (cardId: string) => {
-    // deleteCard(cardId);
-    console.log('[stub] deleteCard', cardId);
+    deleteCard.mutate(cardId);
   };
 
+  if (isLoading) return <div>読み込み中...</div>;
+  if (isError)
+    return <div>エラーが発生しました: {(error as Error).message}</div>;
   return (
     <main className="flex-1 bg-gray-50">
       <div className="max-w-[1536px] mx-auto px-6 py-8">
@@ -99,7 +76,7 @@ export default function CardListPage() {
           <CardListPageHeader
             deckName={deck?.name ?? ''}
             onEditDeck={() => setOpenEditDeck(true)}
-            onAddCard={() => setOpenCreateCard(true)}
+            onCreateCard={() => setOpenCreateCard(true)}
           />
           <CardList
             cards={cards}
@@ -115,19 +92,16 @@ export default function CardListPage() {
           open={openEditDeck}
           onClose={() => setOpenEditDeck(false)}
           initialDeck={deck}
-          onSave={(values) => {
-            console.log('[stub] updateDeck', deckId, values);
-          }}
+          onSave={handleEditDeck}
         />
       )}
 
       {/* カード作成モーダル */}
       <CardCreateModal
         open={openCreateCard}
+        deckId={deckId}
         onClose={() => setOpenCreateCard(false)}
-        onCreate={(values) => {
-          console.log('[stub] createCard', values);
-        }}
+        onCreate={handleCreateCard}
       />
 
       {/* カード編集モーダル */}
@@ -136,9 +110,7 @@ export default function CardListPage() {
           open={!!editingCard}
           onClose={() => setEditingCard(null)}
           initialCard={editingCard}
-          onSave={(values) => {
-            console.log('[stub] updateCard', editingCard.id, values);
-          }}
+          onSave={handleUpdateCard}
         />
       )}
     </main>

--- a/frontend/app/(main)/decks/page.tsx
+++ b/frontend/app/(main)/decks/page.tsx
@@ -3,6 +3,7 @@
 import { useDeckMutations } from '@/features/deck/hooks/useDeckMutations';
 import DeckGrid from '../../../features/deck/components/DeckGrid';
 import { useDecks } from '@/features/deck/hooks/useDecks';
+import { useRouter } from 'next/navigation';
 
 import { components } from '@memo-anki/shared';
 import { useState } from 'react';
@@ -10,25 +11,21 @@ import DeckCreateModal from '@/features/deck/components/DeckCreateModal';
 type CreateDeckRequest = components['schemas']['CreateDeckRequest'];
 
 export default function DeckListPage() {
+  //router
+  const router = useRouter();
   // tanstackquery
   const { createDeck, deleteDeck } = useDeckMutations();
   const { data: decks, isLoading, isError, error } = useDecks();
 
   // useState
   const [open, setOpen] = useState(false);
-  const openModal = () => {
-    setOpen(true);
-  };
-  const closeModal = () => {
-    setOpen(false);
-  };
+
   // CRUD(可読性のためにラップしている)
-  // 以下二つはのちにlinkをつける
   const handleReview = () => {
     console.log('復習:link');
   };
-  const handleEdit = () => {
-    console.log('編集:link');
+  const handleEdit = (deckId: string) => {
+    router.push(`/decks/${deckId}`);
   };
   const handleDelete = (deckId: string) => {
     deleteDeck.mutate(deckId);
@@ -54,7 +51,7 @@ export default function DeckListPage() {
               <h1 className="text-[20px] font-bold">デッキ一覧</h1>
               <button
                 onClick={() => {
-                  openModal();
+                  setOpen(true);
                 }}
                 className="mt-4 w-25 h-9 rounded-md bg-indigo-600 hover:bg-indigo-800 text-white text-sm font-semibold"
               >
@@ -74,7 +71,9 @@ export default function DeckListPage() {
         </div>
         <DeckCreateModal
           open={open}
-          onClose={closeModal}
+          onClose={() => {
+            setOpen(false);
+          }}
           onCreate={handleCreate}
         />
       </main>

--- a/frontend/features/card/components/CardCreateModal.tsx
+++ b/frontend/features/card/components/CardCreateModal.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+
+type FormValues = {
+  name: string;
+  description: string;
+};
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (data: FormValues) => void;
+};
+
+export default function CardCreateModal({ open, onClose, onCreate }: Props) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({ defaultValues: { name: '', description: '' } });
+
+  if (!open) return null;
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const onSubmit = (data: FormValues) => {
+    onCreate({
+      name: data.name.trim(),
+      description: data.description.trim(),
+    });
+    reset();
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-4"
+      onClick={handleClose}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl w-full max-w-[440px] overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-6 pt-5 pb-3 border-b border-gray-200">
+          <h2 className="text-[16px] font-bold text-gray-900">
+            カードを新規作成
+          </h2>
+        </div>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="px-6 py-5">
+          <div className="mb-4">
+            <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+              カード名 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              autoFocus
+              {...register('name', {
+                required: 'カード名は必須です',
+                maxLength: {
+                  value: 50,
+                  message: '50文字以内で入力してください',
+                },
+              })}
+              placeholder="例: 基本情報技術者試験 第1章"
+              className="input input-bordered w-full"
+            />
+            {errors.name && (
+              <p className="text-red-500 text-[12px] mt-1">
+                {errors.name.message}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+              内容
+            </label>
+            <textarea
+              {...register('description', {
+                maxLength: {
+                  value: 10000,
+                  message: '10000文字以内で入力してください',
+                },
+              })}
+              placeholder="カードの内容を入力してください"
+              className="textarea textarea-bordered w-full min-h-[88px]"
+            />
+            {errors.description && (
+              <p className="text-red-500 text-[12px] mt-1">
+                {errors.description.message}
+              </p>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2 mt-6">
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={handleClose}
+            >
+              戻る
+            </button>
+            <button type="submit" className="btn btn-primary btn-sm">
+              作成
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/features/card/components/CardCreateModal.tsx
+++ b/frontend/features/card/components/CardCreateModal.tsx
@@ -1,25 +1,55 @@
 'use client';
 
 import { useForm } from 'react-hook-form';
+import { components } from '@memo-anki/shared';
+import { useEffect } from 'react';
+type CreateCardRequest = components['schemas']['CreateCardRequest'];
 
 type FormValues = {
+  isQuiz: boolean;
   name: string;
-  description: string;
+  content?: string;
+  question?: string;
+  answer?: string;
 };
 
 type Props = {
   open: boolean;
+  deckId: string;
   onClose: () => void;
-  onCreate: (data: FormValues) => void;
+  onCreate: (data: CreateCardRequest) => void;
 };
 
-export default function CardCreateModal({ open, onClose, onCreate }: Props) {
+export default function CardCreateModal({
+  open,
+  deckId,
+  onClose,
+  onCreate,
+}: Props) {
+  // useForm
   const {
     register,
     handleSubmit,
     reset,
+    resetField,
+    watch,
     formState: { errors },
-  } = useForm<FormValues>({ defaultValues: { name: '', description: '' } });
+  } = useForm<FormValues>({
+    defaultValues: {
+      isQuiz: false,
+      name: '',
+      content: '',
+      question: '',
+      answer: '',
+    },
+  });
+  // type変更時のreset処理
+  const isQuiz = watch('isQuiz');
+  useEffect(() => {
+    resetField('content');
+    resetField('question');
+    resetField('answer');
+  }, [isQuiz, resetField]);
 
   if (!open) return null;
 
@@ -29,10 +59,15 @@ export default function CardCreateModal({ open, onClose, onCreate }: Props) {
   };
 
   const onSubmit = (data: FormValues) => {
-    onCreate({
-      name: data.name.trim(),
-      description: data.description.trim(),
-    });
+    const request: CreateCardRequest = {
+      deckId,
+      type: data.isQuiz ? 1 : 0,
+      name: data.name,
+      content: data.content || undefined,
+      question: data.question || undefined,
+      answer: data.answer || undefined,
+    };
+    onCreate(request);
     reset();
     onClose();
   };
@@ -46,13 +81,21 @@ export default function CardCreateModal({ open, onClose, onCreate }: Props) {
         className="bg-white rounded-xl shadow-2xl w-full max-w-[440px] overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="px-6 pt-5 pb-3 border-b border-gray-200">
-          <h2 className="text-[16px] font-bold text-gray-900">
-            カードを新規作成
-          </h2>
-        </div>
-
         <form onSubmit={handleSubmit(onSubmit)} className="px-6 py-5">
+          <div className="flex items-center justify-between  pb-3 border-b border-gray-200">
+            <h2 className="text-[16px] font-bold text-gray-900">
+              カードを新規作成
+            </h2>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <span className="text-[14px]">クイズモード</span>
+              <input
+                type="checkbox"
+                className="checkbox"
+                {...register('isQuiz')}
+              />
+            </label>
+          </div>
+
           <div className="mb-4">
             <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
               カード名 <span className="text-red-500">*</span>
@@ -76,27 +119,74 @@ export default function CardCreateModal({ open, onClose, onCreate }: Props) {
               </p>
             )}
           </div>
-
-          <div>
-            <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
-              内容
-            </label>
-            <textarea
-              {...register('description', {
-                maxLength: {
-                  value: 10000,
-                  message: '10000文字以内で入力してください',
-                },
-              })}
-              placeholder="カードの内容を入力してください"
-              className="textarea textarea-bordered w-full min-h-[88px]"
-            />
-            {errors.description && (
-              <p className="text-red-500 text-[12px] mt-1">
-                {errors.description.message}
-              </p>
-            )}
-          </div>
+          {!isQuiz && (
+            <>
+              <div>
+                <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+                  内容
+                </label>
+                <textarea
+                  {...register('content', {
+                    maxLength: {
+                      value: 10000,
+                      message: '10000文字以内で入力してください',
+                    },
+                  })}
+                  placeholder="内容を入力してください"
+                  className="textarea textarea-bordered w-full min-h-[88px]"
+                />
+                {errors.content && (
+                  <p className="text-red-500 text-[12px] mt-1">
+                    {errors.content.message}
+                  </p>
+                )}
+              </div>
+            </>
+          )}
+          {isQuiz && (
+            <>
+              <div className="mb-4">
+                <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+                  問題
+                </label>
+                <textarea
+                  {...register('question', {
+                    maxLength: {
+                      value: 5000,
+                      message: '5000文字以内で入力してください',
+                    },
+                  })}
+                  placeholder="例: WWWとは？"
+                  className="textarea textarea-bordered w-full min-h-[88px]"
+                />
+                {errors.question && (
+                  <p className="text-red-500 text-[12px] mt-1">
+                    {errors.question.message}
+                  </p>
+                )}
+              </div>
+              <div>
+                <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+                  正答
+                </label>
+                <textarea
+                  {...register('answer', {
+                    maxLength: {
+                      value: 5000,
+                      message: '5000文字以内で入力してください',
+                    },
+                  })}
+                  placeholder="例: World Wide Webの略称です"
+                  className="textarea textarea-bordered w-full min-h-[88px]"
+                />
+                {errors.answer && (
+                  <p className="text-red-500 text-[12px] mt-1">
+                    {errors.answer.message}
+                  </p>
+                )}
+              </div>
+            </>
+          )}
 
           <div className="flex justify-end gap-2 mt-6">
             <button
@@ -106,8 +196,8 @@ export default function CardCreateModal({ open, onClose, onCreate }: Props) {
             >
               戻る
             </button>
-            <button type="submit" className="btn btn-primary btn-sm">
-              作成
+            <button type="submit" className="btn btn-primary btn-sm rounded-md">
+              保存
             </button>
           </div>
         </form>

--- a/frontend/features/card/components/CardEditModal.tsx
+++ b/frontend/features/card/components/CardEditModal.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { components } from '@memo-anki/shared';
+
+type Card = components['schemas']['CardResponse'];
+
+type FormValues = {
+  name: string;
+  description: string;
+};
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  initialCard: Card;
+  onSave: (data: FormValues) => void;
+};
+
+export default function CardEditModal({
+  open,
+  onClose,
+  initialCard,
+  onSave,
+}: Props) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues: {
+      name: initialCard.name,
+      description: String(initialCard.content ?? initialCard.question ?? ''),
+    },
+  });
+
+  if (!open) return null;
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const onSubmit = (data: FormValues) => {
+    onSave({
+      name: data.name.trim(),
+      description: data.description.trim(),
+    });
+    reset();
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-4"
+      onClick={handleClose}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl w-full max-w-[440px] overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-6 pt-5 pb-3 border-b border-gray-200">
+          <h2 className="text-[16px] font-bold text-gray-900">カードを編集</h2>
+        </div>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="px-6 py-5">
+          <div className="mb-4">
+            <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+              カード名 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              autoFocus
+              {...register('name', {
+                required: 'カード名は必須です',
+                maxLength: {
+                  value: 50,
+                  message: '50文字以内で入力してください',
+                },
+              })}
+              className="input input-bordered w-full"
+            />
+            {errors.name && (
+              <p className="text-red-500 text-[12px] mt-1">
+                {errors.name.message}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+              内容
+            </label>
+            <textarea
+              {...register('description', {
+                maxLength: {
+                  value: 10000,
+                  message: '10000文字以内で入力してください',
+                },
+              })}
+              className="textarea textarea-bordered w-full min-h-[88px]"
+            />
+            {errors.description && (
+              <p className="text-red-500 text-[12px] mt-1">
+                {errors.description.message}
+              </p>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2 mt-6">
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={handleClose}
+            >
+              戻る
+            </button>
+            <button type="submit" className="btn btn-primary btn-sm">
+              保存
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/features/card/components/CardEditModal.tsx
+++ b/frontend/features/card/components/CardEditModal.tsx
@@ -1,20 +1,24 @@
 'use client';
 
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { components } from '@memo-anki/shared';
 
 type Card = components['schemas']['CardResponse'];
+type UpdateCardRequest = components['schemas']['UpdateCardRequest'];
 
 type FormValues = {
   name: string;
-  description: string;
+  content?: string;
+  question?: string;
+  answer?: string;
 };
 
 type Props = {
   open: boolean;
   onClose: () => void;
   initialCard: Card;
-  onSave: (data: FormValues) => void;
+  onSave: (cardId: string, body: UpdateCardRequest) => void;
 };
 
 export default function CardEditModal({
@@ -23,17 +27,27 @@ export default function CardEditModal({
   initialCard,
   onSave,
 }: Props) {
+  // typeは変更不可。type変更が必要な場合はカードを作り直す運用
+  const isQuiz = initialCard.type === 1;
+
   const {
     register,
     handleSubmit,
     reset,
     formState: { errors },
-  } = useForm<FormValues>({
-    defaultValues: {
-      name: initialCard.name,
-      description: String(initialCard.content ?? initialCard.question ?? ''),
-    },
-  });
+  } = useForm<FormValues>();
+
+  // 開くたびに初期値をフォームへ流し込む
+  useEffect(() => {
+    if (open) {
+      reset({
+        name: initialCard.name,
+        content: String(initialCard.content ?? ''),
+        question: String(initialCard.question ?? ''),
+        answer: String(initialCard.answer ?? ''),
+      });
+    }
+  }, [open, initialCard, reset]);
 
   if (!open) return null;
 
@@ -43,11 +57,13 @@ export default function CardEditModal({
   };
 
   const onSubmit = (data: FormValues) => {
-    onSave({
-      name: data.name.trim(),
-      description: data.description.trim(),
-    });
-    reset();
+    const request: UpdateCardRequest = {
+      name: data.name,
+      content: !isQuiz ? data.content || undefined : undefined,
+      question: isQuiz ? data.question || undefined : undefined,
+      answer: isQuiz ? data.answer || undefined : undefined,
+    };
+    onSave(initialCard.id, request);
     onClose();
   };
 
@@ -60,12 +76,23 @@ export default function CardEditModal({
         className="bg-white rounded-xl shadow-2xl w-full max-w-[440px] overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="px-6 pt-5 pb-3 border-b border-gray-200">
-          <h2 className="text-[16px] font-bold text-gray-900">カードを編集</h2>
-        </div>
-
         <form onSubmit={handleSubmit(onSubmit)} className="px-6 py-5">
-          <div className="mb-4">
+          <div className="flex items-center justify-between pb-3 border-b border-gray-200">
+            <h2 className="text-[16px] font-bold text-gray-900">
+              カードを編集
+            </h2>
+            <span
+              className={`inline-block w-fit px-1.5 py-px rounded-full border text-[11px] font-semibold ${
+                isQuiz
+                  ? 'border-fuchsia-200 bg-fuchsia-50 text-fuchsia-500'
+                  : 'border-blue-200 bg-blue-50 text-blue-500'
+              }`}
+            >
+              {isQuiz ? 'QUIZ' : 'NOTE'}
+            </span>
+          </div>
+
+          <div className="mb-4 mt-4">
             <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
               カード名 <span className="text-red-500">*</span>
             </label>
@@ -88,25 +115,73 @@ export default function CardEditModal({
             )}
           </div>
 
-          <div>
-            <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
-              内容
-            </label>
-            <textarea
-              {...register('description', {
-                maxLength: {
-                  value: 10000,
-                  message: '10000文字以内で入力してください',
-                },
-              })}
-              className="textarea textarea-bordered w-full min-h-[88px]"
-            />
-            {errors.description && (
-              <p className="text-red-500 text-[12px] mt-1">
-                {errors.description.message}
-              </p>
-            )}
-          </div>
+          {!isQuiz && (
+            <div>
+              <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+                内容
+              </label>
+              <textarea
+                {...register('content', {
+                  maxLength: {
+                    value: 10000,
+                    message: '10000文字以内で入力してください',
+                  },
+                })}
+                placeholder="内容を入力してください"
+                className="textarea textarea-bordered w-full min-h-[88px]"
+              />
+              {errors.content && (
+                <p className="text-red-500 text-[12px] mt-1">
+                  {errors.content.message}
+                </p>
+              )}
+            </div>
+          )}
+
+          {isQuiz && (
+            <>
+              <div className="mb-4">
+                <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+                  問題
+                </label>
+                <textarea
+                  {...register('question', {
+                    maxLength: {
+                      value: 5000,
+                      message: '5000文字以内で入力してください',
+                    },
+                  })}
+                  placeholder="例: WWWとは？"
+                  className="textarea textarea-bordered w-full min-h-[88px]"
+                />
+                {errors.question && (
+                  <p className="text-red-500 text-[12px] mt-1">
+                    {errors.question.message}
+                  </p>
+                )}
+              </div>
+              <div>
+                <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+                  正答
+                </label>
+                <textarea
+                  {...register('answer', {
+                    maxLength: {
+                      value: 5000,
+                      message: '5000文字以内で入力してください',
+                    },
+                  })}
+                  placeholder="例: World Wide Webの略称です"
+                  className="textarea textarea-bordered w-full min-h-[88px]"
+                />
+                {errors.answer && (
+                  <p className="text-red-500 text-[12px] mt-1">
+                    {errors.answer.message}
+                  </p>
+                )}
+              </div>
+            </>
+          )}
 
           <div className="flex justify-end gap-2 mt-6">
             <button
@@ -116,7 +191,7 @@ export default function CardEditModal({
             >
               戻る
             </button>
-            <button type="submit" className="btn btn-primary btn-sm">
+            <button type="submit" className="btn btn-primary btn-sm rounded-md">
               保存
             </button>
           </div>

--- a/frontend/features/card/components/CardList.tsx
+++ b/frontend/features/card/components/CardList.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { components } from '@memo-anki/shared';
+import CardRow from './CardRow';
+
+type Card = components['schemas']['CardResponse'];
+
+type CardListProps = {
+  cards: Card[];
+  onEdit: (cardId: string) => void;
+  onDelete: (cardId: string) => void;
+};
+
+export default function CardList({ cards, onEdit, onDelete }: CardListProps) {
+  return (
+    <>
+      {/* 列ラベル（md以上で詳細・日時列を表示） */}
+      <div
+        className="
+          grid gap-4
+          grid-cols-[1fr_auto] md:grid-cols-[1fr_2fr_auto_auto]
+          px-4 py-2
+          bg-gray-50
+          border-b-2 border-gray-200
+          text-[11.5px] font-semibold uppercase tracking-wider text-gray-500
+        "
+      >
+        <span>カード名 / タイプ</span>
+        <span className="hidden md:block">詳細</span>
+        <span className="hidden md:block">作成日時</span>
+        <span />
+      </div>
+
+      {/* 行 */}
+      <ul>
+        {cards.length === 0 ? (
+          <li className="px-4 py-10 text-center text-[13px] text-gray-400">
+            カードがまだありません
+          </li>
+        ) : (
+          cards.map((card) => (
+            <CardRow
+              key={card.id}
+              card={card}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
+          ))
+        )}
+      </ul>
+    </>
+  );
+}

--- a/frontend/features/card/components/CardListPageHeader.tsx
+++ b/frontend/features/card/components/CardListPageHeader.tsx
@@ -5,13 +5,13 @@ import Link from 'next/link';
 type CardListPageHeaderProps = {
   deckName: string;
   onEditDeck: () => void;
-  onAddCard: () => void;
+  onCreateCard: () => void;
 };
 
 export default function CardListPageHeader({
   deckName,
   onEditDeck,
-  onAddCard,
+  onCreateCard,
 }: CardListPageHeaderProps) {
   return (
     <div className="flex items-center justify-between px-8 py-5 border-b border-gray-200">
@@ -35,7 +35,7 @@ export default function CardListPageHeader({
         >
           デッキ編集
         </button>
-        <button onClick={onAddCard} className="btn btn-primary btn-sm">
+        <button onClick={onCreateCard} className="btn btn-primary btn-sm">
           ＋ カード追加
         </button>
       </div>

--- a/frontend/features/card/components/CardListPageHeader.tsx
+++ b/frontend/features/card/components/CardListPageHeader.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import Link from 'next/link';
+
+type CardListPageHeaderProps = {
+  deckName: string;
+  onEditDeck: () => void;
+  onAddCard: () => void;
+};
+
+export default function CardListPageHeader({
+  deckName,
+  onEditDeck,
+  onAddCard,
+}: CardListPageHeaderProps) {
+  return (
+    <div className="flex items-center justify-between px-8 py-5 border-b border-gray-200">
+      {/* 左：パンくず + タイトル */}
+      <div>
+        <p className="text-[12px] text-gray-400 mb-0.5">
+          <Link href="/decks" className="hover:underline">
+            デッキ一覧
+          </Link>
+          <span className="mx-1">›</span>
+          <span className="text-gray-600 font-medium">{deckName}</span>
+        </p>
+        <h1 className="text-[20px] font-bold text-gray-900">カード一覧</h1>
+      </div>
+
+      {/* 右：デッキ編集 + カード追加 */}
+      <div className="flex items-center gap-2">
+        <button
+          onClick={onEditDeck}
+          className="btn btn-outline btn-primary btn-sm"
+        >
+          デッキ編集
+        </button>
+        <button onClick={onAddCard} className="btn btn-primary btn-sm">
+          ＋ カード追加
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/features/card/components/CardRow.tsx
+++ b/frontend/features/card/components/CardRow.tsx
@@ -48,13 +48,13 @@ export default function CardRow({ card, onEdit, onDelete }: CardRowProps) {
       <div className="flex gap-2 shrink-0">
         <button
           onClick={() => onEdit(card.id)}
-          className="btn btn-outline btn-sm"
+          className="btn btn-outline btn-sm flex-1 border-black text-black"
         >
           編集
         </button>
         <button
           onClick={() => onDelete(card.id)}
-          className="btn btn-outline btn-error btn-sm font-bold"
+          className="btn btn-outline btn-error btn-sm flex-1"
         >
           削除
         </button>

--- a/frontend/features/card/components/CardRow.tsx
+++ b/frontend/features/card/components/CardRow.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { components } from '@memo-anki/shared';
+import CardTypeBadge from './CardTypeBadge';
+import { buildCardDetail, formatDate } from '../utils/cardView';
+
+type Card = components['schemas']['CardResponse'];
+
+type CardRowProps = {
+  card: Card;
+  onEdit: (cardId: string) => void;
+  onDelete: (cardId: string) => void;
+};
+
+export default function CardRow({ card, onEdit, onDelete }: CardRowProps) {
+  const detail = buildCardDetail(card);
+  const date = formatDate(card.updatedAt);
+
+  return (
+    <li
+      className="
+        grid items-center gap-4
+        grid-cols-[1fr_auto] md:grid-cols-[1fr_2fr_auto_auto]
+        px-4 py-3
+        border-b border-gray-200 last:border-b-0
+        bg-white hover:bg-gray-50
+      "
+    >
+      {/* カード名 + タイプバッジ */}
+      <div className="flex flex-col gap-1 min-w-0">
+        <span className="text-[13.5px] font-semibold text-gray-900 truncate">
+          {card.name}
+        </span>
+        <CardTypeBadge type={card.type} />
+      </div>
+
+      {/* 詳細（md以上で表示） */}
+      <div className="hidden md:block text-[12.5px] text-gray-500 leading-snug truncate">
+        {detail}
+      </div>
+
+      {/* 日時（md以上で表示） */}
+      <div className="hidden md:block text-[12px] text-gray-400 whitespace-nowrap">
+        {date}
+      </div>
+
+      {/* ボタン */}
+      <div className="flex gap-2 shrink-0">
+        <button
+          onClick={() => onEdit(card.id)}
+          className="btn btn-outline btn-sm"
+        >
+          編集
+        </button>
+        <button
+          onClick={() => onDelete(card.id)}
+          className="btn btn-outline btn-error btn-sm font-bold"
+        >
+          削除
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/frontend/features/card/components/CardTypeBadge.tsx
+++ b/frontend/features/card/components/CardTypeBadge.tsx
@@ -1,0 +1,23 @@
+import { components } from '@memo-anki/shared';
+
+type CardType = components['schemas']['CardResponse']['type'];
+
+type CardTypeBadgeProps = {
+  type: CardType;
+};
+
+/** type によってNote, Quizを分岐してバッチを表示 */
+export default function CardTypeBadge({ type }: CardTypeBadgeProps) {
+  if (type === 0) {
+    return (
+      <span className="inline-block w-fit px-1.5 py-px rounded-full border border-blue-200 bg-blue-50 text-blue-500 text-[11px] font-semibold">
+        NOTE
+      </span>
+    );
+  }
+  return (
+    <span className="inline-block w-fit px-1.5 py-px rounded-full border border-fuchsia-200 bg-fuchsia-50 text-fuchsia-500 text-[11px] font-semibold">
+      QUIZ
+    </span>
+  );
+}

--- a/frontend/features/card/hooks/useCardMutations.ts
+++ b/frontend/features/card/hooks/useCardMutations.ts
@@ -1,0 +1,66 @@
+import { apiClient } from '@/lib/api/client';
+import { HttpError } from '@/lib/api/httpError';
+import { HttpStatus } from '@/lib/api/statusCodes';
+import { components } from '@memo-anki/shared';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+type CreateCardRequest = components['schemas']['CreateCardRequest'];
+type UpdateCardRequest = components['schemas']['UpdateCardRequest'];
+
+// 後で書き直し
+export function useCardMutations() {
+  const queryClient = useQueryClient();
+
+  const handleSuccess = (action: string) => () => {
+    queryClient.invalidateQueries({ queryKey: ['cards'], exact: false });
+    toast.success(`${action}に成功しました`);
+  };
+
+  const handleError = (err: unknown) => {
+    if (err instanceof HttpError) {
+      console.error(`[Card API Error] ${err.statusCode}: ${err.message}`);
+      switch (err.statusCode) {
+        case HttpStatus.BAD_REQUEST:
+          toast.error('正しい形式で入力してください');
+          break;
+        case HttpStatus.CONFLICT:
+          toast.error('同じ名前のカードが既に存在します');
+          break;
+        case HttpStatus.NOT_FOUND:
+          toast.error('カードが見つかりません');
+          break;
+        default:
+          toast.error('サーバーエラーが発生しました');
+      }
+    } else {
+      console.error('[Network Error]', err);
+      toast.error('ネットワークエラーが発生しました');
+    }
+  };
+  /** カード削除 Fetch */
+  const deleteCard = useMutation({
+    mutationFn: (cardId: string) => apiClient(`/card/${cardId}`, 'DELETE'),
+    onSuccess: handleSuccess('削除'),
+    onError: handleError,
+  });
+  /** カード作成 Fetch */
+  const createCard = useMutation({
+    mutationFn: (data: CreateCardRequest) => apiClient('/card', 'POST', data),
+    onSuccess: handleSuccess('作成'),
+    onError: handleError,
+  });
+  /** カード更新 Fetch */
+  const updateCard = useMutation({
+    mutationFn: ([cardId, body]: [string, UpdateCardRequest]) =>
+      apiClient(`/card/${cardId}`, 'PUT', body),
+    onSuccess: handleSuccess('更新'),
+    onError: handleError,
+  });
+
+  return {
+    deleteCard,
+    createCard,
+    updateCard,
+  };
+}

--- a/frontend/features/card/hooks/useCards.ts
+++ b/frontend/features/card/hooks/useCards.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '@/lib/api/client';
+import { components } from '@memo-anki/shared';
+import { useQuery } from '@tanstack/react-query';
+
+type Card = components['schemas']['CardResponse'];
+
+export const useCards = (deckId: string) => {
+  return useQuery<Card[]>({
+    queryKey: ['cards', deckId],
+    queryFn: async () => {
+      const all = (await apiClient('/card', 'GET')) as Card[];
+      return all.filter((c) => c.deckId === deckId);
+    },
+  });
+};

--- a/frontend/features/card/utils/cardView.ts
+++ b/frontend/features/card/utils/cardView.ts
@@ -1,0 +1,22 @@
+import { components } from '@memo-anki/shared';
+
+type Card = components['schemas']['CardResponse'];
+
+export function buildCardDetail(card: Card): string {
+  if (card.type === 0) return String(card.content ?? '');
+  const q = card.question ? `Q: ${String(card.question)}` : '';
+  const a = card.answer ? `A: ${String(card.answer)}` : '';
+  return [q, a].filter(Boolean).join('  '); // 空白を除去してq,a結合
+}
+// 単純なフォーマット utilsへ共有関数化するかも
+export function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}

--- a/frontend/features/deck/components/DeckCard.tsx
+++ b/frontend/features/deck/components/DeckCard.tsx
@@ -31,7 +31,7 @@ export default function DeckCard({
       {/* 復習ボタン */}
       <button
         onClick={() => onReview(deck.id)}
-        className="mt-4 w-full h-9 rounded-md bg-indigo-600 hover:bg-indigo-800 text-white text-sm font-semibold"
+        className="btn btn-primary w-full mt-4"
       >
         復習
       </button>
@@ -40,13 +40,13 @@ export default function DeckCard({
       <div className="mt-2 flex gap-2">
         <button
           onClick={() => onEdit(deck.id)}
-          className="flex-1 h-[30px] rounded-md border border-gray-300 bg-white text-gray-900 text-[12.5px] font-semibold hover:bg-gray-100"
+          className="btn btn-outline btn-sm flex-1"
         >
           編集
         </button>
         <button
           onClick={() => onDelete(deck.id)}
-          className="flex-1 h-[30px] rounded-md border border-red-500 bg-white text-red-500 text-[12.5px] font-bold hover:bg-red-50"
+          className="btn btn-outline btn-error btn-sm flex-1"
         >
           削除
         </button>

--- a/frontend/features/deck/components/DeckUpdateModal.tsx
+++ b/frontend/features/deck/components/DeckUpdateModal.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { components } from '@memo-anki/shared';
+
+type DeckResponse = components['schemas']['DeckResponse'];
+type UpdateDeckRequest = components['schemas']['UpdateDeckRequest'];
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  initialDeck: DeckResponse;
+  onSave: (values: UpdateDeckRequest) => void;
+};
+
+type FormValues = {
+  name: string;
+  description: string;
+};
+/** CreateModalにカラム値初期設定しただけ */
+export default function DeckUpdateModal({
+  open,
+  onClose,
+  initialDeck,
+  onSave,
+}: Props) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>();
+
+  // 閉じるたびに編集対象のデッキ情報をフォームにセット
+  useEffect(() => {
+    if (open) {
+      reset({
+        name: initialDeck.name,
+        description: initialDeck.description ?? '',
+      });
+    }
+  }, [open, initialDeck, reset]);
+
+  if (!open) return null;
+
+  const onSubmit = (data: FormValues) => {
+    onSave({
+      name: data.name.trim(),
+      description: data.description.trim() || undefined,
+    });
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl w-full max-w-[440px] overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-6 pt-5 pb-3 border-b border-gray-200">
+          <h2 className="text-[16px] font-bold text-gray-900">デッキを編集</h2>
+        </div>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="px-6 py-5">
+          <div className="mb-4">
+            <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+              デッキ名 <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              autoFocus
+              {...register('name', {
+                required: 'デッキ名は必須です',
+                maxLength: {
+                  value: 50,
+                  message: '50文字以内で入力してください',
+                },
+              })}
+              className="input input-bordered w-full"
+            />
+            {errors.name && (
+              <p className="text-red-500 text-[12px] mt-1">
+                {errors.name.message}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-[13px] font-semibold text-gray-700 mb-1.5">
+              説明
+            </label>
+            <textarea
+              {...register('description', {
+                maxLength: {
+                  value: 200,
+                  message: '200文字以内で入力してください',
+                },
+              })}
+              className="textarea textarea-bordered w-full min-h-[88px]"
+            />
+            {errors.description && (
+              <p className="text-red-500 text-[12px] mt-1">
+                {errors.description.message}
+              </p>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2 mt-6">
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={onClose}
+            >
+              戻る
+            </button>
+            <button type="submit" className="btn btn-primary btn-sm">
+              保存
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/features/deck/components/DeckUpdateModal.tsx
+++ b/frontend/features/deck/components/DeckUpdateModal.tsx
@@ -11,7 +11,8 @@ type Props = {
   open: boolean;
   onClose: () => void;
   initialDeck: DeckResponse;
-  onSave: (values: UpdateDeckRequest) => void;
+  onSave: (deckId: string, body: UpdateDeckRequest) => void; //mutation
+  //deckId: string, body: UpdateDeckRequest
 };
 
 type FormValues = {
@@ -44,11 +45,8 @@ export default function DeckUpdateModal({
 
   if (!open) return null;
 
-  const onSubmit = (data: FormValues) => {
-    onSave({
-      name: data.name.trim(),
-      description: data.description.trim() || undefined,
-    });
+  const onSubmit = (formValues: FormValues) => {
+    onSave(initialDeck.id, formValues);
     onClose();
   };
 

--- a/frontend/features/deck/hooks/useDeckMutations.ts
+++ b/frontend/features/deck/hooks/useDeckMutations.ts
@@ -7,6 +7,7 @@ import { HttpError } from '@/lib/api/httpError';
 
 type CreateDeckRequest = components['schemas']['CreateDeckRequest'];
 type UpdateDeckRequest = components['schemas']['UpdateDeckRequest'];
+type Deck = components['schemas']['DeckResponse'];
 
 export const useDeckMutations = () => {
   const queryClient = useQueryClient();
@@ -49,10 +50,16 @@ export const useDeckMutations = () => {
     onError: handleError,
   });
   /** デッキ更新 Fetch */
-  const updateDeck = useMutation({
-    mutationFn: ([deckId, body]: [string, UpdateDeckRequest]) =>
-      apiClient(`/deck/${deckId}`, 'PUT', body),
-    onSuccess: handleSuccess('更新'),
+  const updateDeck = useMutation<Deck, unknown, [string, UpdateDeckRequest]>({
+    mutationFn: ([deckId, body]) =>
+      apiClient(`/deck/${deckId}`, 'PUT', body) as Promise<Deck>,
+    onSuccess: (updated) => {
+      // ['decks'] キャッシュを直接書き換え、購読中のページを再レンダーさせる
+      queryClient.setQueryData<Deck[]>(['decks'], (old) =>
+        old?.map((d) => (d.id === updated.id ? updated : d)),
+      );
+      toast.success('更新に成功しました');
+    },
     onError: handleError,
   });
 

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -6,7 +6,8 @@ const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 // fetchラッパー
 export async function apiClient(url: string, method: string, body?: unknown) {
   // のちにメモリ（zustand）から取得？
-  const accessToken = '';
+  const accessToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2ZjVhMDhlMC1kNzJjLTRlZDUtYjQzOC0xYWZlMmUwOTlmZGMiLCJpYXQiOjE3Nzc3MTE0NjUsImV4cCI6MTc3NzcxMjM2NX0.WNMDROwVUszg4_gNec2tdFN5vhXaPImWhQvP5eT_BnQ';
 
   let res;
   try {
@@ -22,7 +23,13 @@ export async function apiClient(url: string, method: string, body?: unknown) {
   } catch {
     throw new Error('NetworkError');
   }
-  if (!res.ok) throw new HttpError(res.status, 'Fetch Failed');
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    const message = Array.isArray(body?.message)
+      ? body.message.join(', ')
+      : (body?.message ?? 'Fetch Failed');
+    throw new HttpError(res.status, message);
+  }
 
   if (res.status === HttpStatus.NO_CONTENT) return null;
   return res.json();


### PR DESCRIPTION

## 概要
基本的にはデッキ一覧画面から模倣して作成している。ただし、card取得apiがuserごとにcardを取得する仕様になっており、deckごとではないため一部filterが必要な点がある。
- swaggerで誤生成したRecord型を破棄して元カラムの型に修正
- カード画面をAPIに接続(useCards / useCardMutations)
- CardCreateModalにクイズモード切替を実装し、CardEditModalを本実装
- デッキ名変更後にカード画面パンくずが空欄になる不具合を修正


## 主な変更
- useDeckMutations.updateDeckのonSuccessをsetQueryDataに変更し、active observerのないページでもキャッシュ更新が反映されるよう改善
- カード一覧ページのデッキ取得を `useQuery({ queryKey: ['decks'], enabled: false })`
に変更(キャッシュ登録のみ。再fetchはしない方針を維持)

## 注意点
- typeは作成後に途中変更できないようにしている。変更できるようにするとカラムのロジックは複雑になる。
- cardのpage.tsxでダミーのqueryFnを使用している。tanstackqueryの仕様として、queryFnは必須になるのだが、card一覧画面でデッキ一覧の取得は必要がないためダミーを渡して、空配列を渡している。
- apiClientでは、バックエンドから受けっとったメッセージを利用して使えるように整形している。
  