### PR TITLE
Feat/login screen jwt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules/
 
 # claude
 CLAUDE.md
+.claude

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -58,6 +58,12 @@ export class AuthController {
     );
   }
 
+  @Post('logout')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  logout(@Res({ passthrough: true }) res: express.Response) {
+    res.clearCookie('refresh_token', { path: '/' });
+  }
+
   @Post('refresh')
   @HttpCode(HttpStatus.OK)
   @ApiResponse({ status: 200, type: RefreshResponse })

--- a/frontend/app/(main)/decks/layout.tsx
+++ b/frontend/app/(main)/decks/layout.tsx
@@ -1,13 +1,18 @@
+'use client';
+
 import Header from '@/components/Header';
+import { useAuthStore } from '@/lib/store/useAuthStore';
 
 export default function DecksLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const username = useAuthStore((s) => s.username);
+
   return (
     <>
-      <Header userName={'あとでzustand'} />
+      <Header userName={username ?? ''} />
       <main className="flex-1 flex flex-col">{children}</main>
     </>
   );

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,18 +1,35 @@
 'use client';
-import { Toaster } from 'sonner';
 
-// client側の全体の設定
-// ブラウザにあるuserContextのようなもの、client側なのでuseClientを明記
+import { Toaster } from 'sonner';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useState, ReactNode } from 'react';
+import { useState, useEffect, ReactNode } from 'react';
+import { useAuthStore } from '@/lib/store/useAuthStore';
+import { refreshAccessToken } from '@/lib/api/client';
+
+/**
+ * アプリ起動時にrefresh実行。
+ * 取得できないときは情報を破棄。
+ * 取得できるときはATを更新。
+ */
+function AuthInitializer() {
+  const setAccessToken = useAuthStore((s) => s.setAccessToken);
+  const clearAuth = useAuthStore((s) => s.clearAuth);
+
+  useEffect(() => {
+    refreshAccessToken()
+      .then((token) => setAccessToken(token)) //zustandにAT保存
+      .catch(() => clearAuth()); // 失敗でAT, Username初期化
+  }, []);
+
+  return null;
+}
 
 export default function Providers({ children }: { children: ReactNode }) {
-  // useStateの初期化
-  // 毎回インスタンス化させない
   const [queryClient] = useState(() => new QueryClient());
 
   return (
     <QueryClientProvider client={queryClient}>
+      <AuthInitializer />
       {children}
       <Toaster position="bottom-right" />
     </QueryClientProvider>

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,18 +1,38 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/lib/store/useAuthStore';
+import { apiClient } from '@/lib/api/client';
+
 type HeaderProps = {
   userName: string;
 };
 
 export default function Header({ userName }: HeaderProps) {
+  const router = useRouter();
+  const clearAuth = useAuthStore((s) => s.clearAuth);
+
+  const handleLogout = async () => {
+    //hooksには切り出さない。ログアウトをサーバーに伝えるだけで冗長になる。
+    await apiClient('/auth/logout', 'POST').catch(() => {});
+
+    // apiClientでエラー処理は行われるため握り潰し。以下はエラーでも実行する。
+    clearAuth();
+    router.push('/login');
+  };
+
   return (
     <header className="w-full border-b border-gray-200">
       <div className="flex items-center justify-between px-5 py-4.5">
-        {/* ロゴ 将来的に画像ロゴにする*/}
         <span className="bg-slate-900 text-white font-bold px-2.5 py-1 rounded-md text-[13px]">
           memo-anki
         </span>
-
-        {/* ユーザー名 */}
-        <span className="text-[13px] text-gray-700">{userName}</span>
+        <div className="flex items-center gap-3">
+          <span className="text-[13px] text-gray-700">{userName}</span>
+          <button onClick={handleLogout} className="btn btn-ghost btn-xs">
+            ログアウト
+          </button>
+        </div>
       </div>
     </header>
   );

--- a/frontend/features/auth/hooks/useAuthMutations.ts
+++ b/frontend/features/auth/hooks/useAuthMutations.ts
@@ -15,10 +15,11 @@ type AuthResponse = components['schemas']['AuthResponse'];
 
 export const useAuthMutations = () => {
   const router = useRouter();
-  const setAccessToken = useAuthStore((s) => s.setAccessToken);
+  // zustandからsetAuth()を取り出す
+  const setAuth = useAuthStore((s) => s.setAuth);
 
   const handleSuccess = (res: AuthResponse) => {
-    setAccessToken(res.accessToken);
+    setAuth(res.accessToken, res.username); //zustandにセット
     router.push('/decks');
   };
 

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -1,36 +1,70 @@
 import { HttpError } from './httpError';
 import { HttpStatus } from './statusCodes';
+import { useAuthStore } from '@/lib/store/useAuthStore';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
-// fetchラッパー
+/** api接続処理の流れ */
 export async function apiClient(url: string, method: string, body?: unknown) {
-  // のちにメモリ（zustand）から取得？
-  const accessToken =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2ZjVhMDhlMC1kNzJjLTRlZDUtYjQzOC0xYWZlMmUwOTlmZGMiLCJpYXQiOjE3Nzc3MTE0NjUsImV4cCI6MTc3NzcxMjM2NX0.WNMDROwVUszg4_gNec2tdFN5vhXaPImWhQvP5eT_BnQ';
+  // 通常fetch
+  let res = await fetchOnce(
+    url,
+    method,
+    body,
+    useAuthStore.getState().accessToken,
+  );
 
-  let res;
+  // 401(ATが無効or存在しない)の場合に、リフレッシュして再試行
+  if (res.status === HttpStatus.UNAUTHORIZED) {
+    const newToken = await refreshAccessToken();
+    res = await fetchOnce(url, method, body, newToken);
+  }
+
+  if (!res.ok) throw await toHttpError(res);
+
+  if (res.status === HttpStatus.NO_CONTENT) return null;
+  return res.json();
+}
+
+/** fetchラッパー */
+async function fetchOnce(
+  url: string,
+  method: string,
+  body: unknown,
+  token: string | null,
+): Promise<Response> {
+  const headers: HeadersInit = { 'Content-Type': 'application/json' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+
   try {
-    res = await fetch(`${BASE_URL}${url}`, {
+    return await fetch(`${BASE_URL}${url}`, {
       method,
-      credentials: 'include', // jwtをrequestに含める
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessToken}`,
-      },
+      credentials: 'include', // cookieにRT保存
+      headers,
       body: body ? JSON.stringify(body) : undefined,
     });
   } catch {
     throw new Error('NetworkError');
   }
-  if (!res.ok) {
-    const body = await res.json().catch(() => null);
-    const message = Array.isArray(body?.message)
-      ? body.message.join(', ')
-      : (body?.message ?? 'Fetch Failed');
-    throw new HttpError(res.status, message);
-  }
+}
 
-  if (res.status === HttpStatus.NO_CONTENT) return null;
-  return res.json();
+/** レスポンスのエラーメッセージを整形してHttpErrorを生成する */
+async function toHttpError(res: Response): Promise<HttpError> {
+  const body = await res.json().catch(() => null);
+  // レスポンスメッセージは配列(validation)もしくは文字列で来る
+  const message = Array.isArray(body?.message)
+    ? body.message.join(', ') // 配列なら結合
+    : (body?.message ?? 'Fetch Failed');
+  return new HttpError(res.status, message);
+}
+
+/** リフレッシュ処理 RTを用いてATを取得する */
+export async function refreshAccessToken(): Promise<string> {
+  const res = await fetchOnce('/auth/refresh', 'POST', undefined, null);
+
+  if (!res.ok) throw await toHttpError(res);
+
+  const data = (await res.json()) as { accessToken: string };
+  useAuthStore.getState().setAccessToken(data.accessToken);
+  return data.accessToken;
 }

--- a/frontend/lib/store/useAuthStore.ts
+++ b/frontend/lib/store/useAuthStore.ts
@@ -1,11 +1,30 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 interface AuthState {
   accessToken: string | null;
+  username: string | null;
+  setAuth: (token: string, username: string) => void;
   setAccessToken: (token: string | null) => void;
+  clearAuth: () => void;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
-  accessToken: null,
-  setAccessToken: (token) => set({ accessToken: token }),
-}));
+export const useAuthStore = create<AuthState>()(
+  // 処理を定義している。ファイル読み込み時にこの値で初期化される
+  // usernameをzustandとlocalStorageに保存。
+  persist(
+    (set) => ({
+      accessToken: null,
+      username: null,
+      setAuth: (token, username) => set({ accessToken: token, username }),
+      setAccessToken: (token) => set({ accessToken: token }),
+      clearAuth: () => set({ accessToken: null, username: null }),
+    }),
+    {
+      name: 'auth',
+      storage: createJSONStorage(() => localStorage), // storage種類を選択
+      // ATをzustandに保存（localStorageはXSS対象なのでATは含めない）
+      partialize: (state) => ({ username: state.username }),
+    },
+  ),
+);

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const PUBLIC_PATHS = ['/login'];
+
+/** リクエスト前の割り込み処理 認証の合否によりリダイレクトする */
+export function middleware(request: NextRequest) {
+  // 現在リクエストされているpath名(例:/decks/1)を取得
+  const { pathname } = request.nextUrl;
+  // path名がloginで始まるなら通過。
+  if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
+    return NextResponse.next();
+  }
+
+  // RT Cookieがなければ未認証扱いで/login へ。
+  // RTのチェックはリクエスト送信時におこなわれる。
+  const refreshToken = request.cookies.get('refresh_token');
+  if (!refreshToken) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+  return NextResponse.next();
+}
+
+// _next/static・_next/image・favicon.ico 以外の全リクエストを割り込み対象とする。
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};


### PR DESCRIPTION
## 概要
ログイン画面のJWT。ATのZustand管理・リフレッシュ・ログアウトを実装した。

## 詳細
ログアウト処理は、DBのRT削除までは行っていない。別ブランチでバックエンドの修正を行う。

- zustandの設定
  - Zustand persistでusernameのみlocalStorageに保存した。これにより再読み込みしてもブラウザがlocalstorageにusernameを注入される。（XSS対策のためAT はメモリのみ）

- apiClient のリファクタ
  - ATをzustandから取得
  - fetchOnce / toHttpError 関数として切り出し
  - ATが無効またはない場合に401が返る。その時にリフレッシュ処理を実行。
  内容はresfreshエンドポイントにRTを送信。成功したらATを含めて元リクエストを再試行。失敗したらusername, ATをzustandから破棄。

- providers.tsx
  - アプリ起動時にrefreshAccessTokenを実行し、RTからATを復元する処理を追加。

- middleware.ts
  - リクエストを受け取り処理する前にRTの有無で認証チェックする。

- Header
  - username を Zustand から取得
  - Header にログアウトボタンを追加

- backend logout
  - RT Cookie を clearCookie で削除するエンドポイントを追加