### PR TITLE
Feat/review api

### DIFF
--- a/backend/src/card/card.controller.spec.ts
+++ b/backend/src/card/card.controller.spec.ts
@@ -10,17 +10,20 @@ import { CardController } from './card.controller';
 import { CardService } from './card.service';
 import { ReviewService } from './review.service';
 import { CardResponse } from './dto/card.response';
+import { CardReviewResponse } from './dto/card-review.response';
 import { JwtAuthGuard } from '../auth/jwt.guard';
 import { CreateCardRequest } from './dto/create-card.request';
 import { UpdateCardRequest } from './dto/update-card.request';
+import { ReviewCardRequest } from './dto/review-card.request';
 import { ParseBigIntIdPipe } from '../common/pipes/parse-bigint-id.pipe';
 import { InvalidIdFormatException } from '../common/exceptions/application.exceptions';
 import { Card } from '@prisma/client';
-import { CardType } from '@memo-anki/shared';
+import { CardType, ReviewRating } from '@memo-anki/shared';
 
 describe('CardController', () => {
   let controller: CardController;
   let serviceMock: DeepMockProxy<CardService>;
+  let reviewServiceMock: DeepMockProxy<ReviewService>;
   const targetPipe = new ValidationPipe({ transform: true });
 
   const userId = 'user-123';
@@ -46,6 +49,7 @@ describe('CardController', () => {
 
   beforeEach(async () => {
     serviceMock = mockDeep<CardService>();
+    reviewServiceMock = mockDeep<ReviewService>();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CardController],
@@ -56,7 +60,7 @@ describe('CardController', () => {
         },
         {
           provide: ReviewService,
-          useValue: mockDeep<ReviewService>(),
+          useValue: reviewServiceMock,
         },
       ],
     }).compile();
@@ -208,6 +212,79 @@ describe('CardController', () => {
 
       await expect(controller.deleteCard(userId, '1')).resolves.not.toThrow();
       expect(serviceMock.deleteCard).toHaveBeenCalledWith(userId, '1');
+    });
+  });
+
+  // --- reviewCard ---
+  describe('reviewCard', () => {
+    // 採点後の更新済みカード（versionが+1されている）
+    const updatedCard: Card = { ...mockCardData, version: 1 };
+
+    it('正常系: ReviewServiceに userId/cardId/rating/version が渡されること', async () => {
+      // [試験項目: 採点パススルー]
+      const request: ReviewCardRequest = {
+        rating: ReviewRating.GOOD,
+        version: 0,
+      };
+      reviewServiceMock.reviewCard.mockResolvedValue(updatedCard);
+
+      await controller.reviewCard(userId, '1', request);
+
+      expect(reviewServiceMock.reviewCard).toHaveBeenCalledWith({
+        userId,
+        cardId: '1',
+        rating: ReviewRating.GOOD,
+        version: 0,
+      });
+    });
+
+    it('正常系: 戻り値が CardReviewResponse でラップされていること', async () => {
+      // [試験項目: レスポンス型]
+      reviewServiceMock.reviewCard.mockResolvedValue(updatedCard);
+      const request: ReviewCardRequest = {
+        rating: ReviewRating.GOOD,
+        version: 0,
+      };
+
+      const result = await controller.reviewCard(userId, '1', request);
+
+      expect(result).toBeInstanceOf(CardReviewResponse);
+      // フロントは次の採点でversionを返送するためversionが必須
+      expect(result.version).toBe(1);
+    });
+
+    it('バリデーション: rating が範囲外(4)の場合、400エラー', async () => {
+      // [試験項目: rating範囲外]
+      const invalidRequest = new ReviewCardRequest();
+      invalidRequest.rating = 4 as unknown as ReviewRating; // 不正値で型迂回
+      invalidRequest.version = 0;
+
+      const metadata: ArgumentMetadata = {
+        type: 'body',
+        metatype: ReviewCardRequest,
+        data: '',
+      };
+
+      await expect(
+        targetPipe.transform(invalidRequest, metadata),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('バリデーション: version が負の数の場合、400エラー', async () => {
+      // [試験項目: 負のversion]
+      const invalidRequest = new ReviewCardRequest();
+      invalidRequest.rating = ReviewRating.GOOD;
+      invalidRequest.version = -1;
+
+      const metadata: ArgumentMetadata = {
+        type: 'body',
+        metatype: ReviewCardRequest,
+        data: '',
+      };
+
+      await expect(
+        targetPipe.transform(invalidRequest, metadata),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/backend/src/card/card.controller.ts
+++ b/backend/src/card/card.controller.ts
@@ -20,8 +20,9 @@ import { GetUserId } from '../common/decorators/get-userid.decorator';
 import { CardResponse } from './dto/card.response';
 import { CardReviewResponse } from './dto/card-review.response';
 import { UpdateCardRequest } from './dto/update-card.request';
+import { ReviewCardRequest } from './dto/review-card.request';
 import { Card } from '@prisma/client';
-import { ReviewService } from './review.service';
+import { ReviewCardDto, ReviewService } from './review.service';
 
 @Controller('card')
 export class CardController {
@@ -97,6 +98,12 @@ export class CardController {
     await this.cardService.deleteCard(userId, cardId);
   }
 
+  /**
+   * 復習対象のキューを取得する
+   *
+   * 取得数はデフォルトで10件
+   * @returns ソートされたCard10件
+   */
   @UseGuards(JwtAuthGuard)
   @Get('review')
   @ApiQuery({
@@ -113,5 +120,31 @@ export class CardController {
       userId,
     });
     return responses.map((card) => new CardReviewResponse(card));
+  }
+
+  /** 採点を反映する */
+  @UseGuards(JwtAuthGuard)
+  @Post(':cardId/review')
+  @ApiParam({
+    name: 'cardId',
+    example: '1',
+    description: 'bigint ID of the card',
+  })
+  @ApiResponse({ status: 200, type: CardReviewResponse })
+  async reviewCard(
+    @GetUserId() userId: string,
+    @Param('cardId', ParseBigIntIdPipe) cardId: string,
+    @Body() request: ReviewCardRequest,
+  ) {
+    const reviewCardDto: ReviewCardDto = {
+      userId,
+      cardId,
+      rating: request.rating,
+      version: request.version,
+    };
+    const updated = await this.reviewService.reviewCard(reviewCardDto);
+
+    // 更新するだけなのでレスポンスいらないのでは？→いったん置いておく
+    return new CardReviewResponse(updated);
   }
 }

--- a/backend/src/card/card.repository.interface.ts
+++ b/backend/src/card/card.repository.interface.ts
@@ -15,6 +15,12 @@ export interface ICardRepository {
     data: Prisma.CardUncheckedUpdateInput,
   ): Promise<Card>;
   findReviewCards(userId: string, deckId: bigint): Promise<Card[]>;
+  updateReviewWithVersion(
+    userId: string,
+    cardId: bigint,
+    version: number,
+    data: Prisma.CardUncheckedUpdateInput,
+  ): Promise<Card | null>;
 }
 
 // DI用のトークン

--- a/backend/src/card/card.repository.ts
+++ b/backend/src/card/card.repository.ts
@@ -76,6 +76,12 @@ export class CardRepository implements ICardRepository {
     });
   }
 
+  /**
+   * 復習対象のカードを取得する
+   *
+   * デフォルトの取得数は10件
+   * @returns nextReviewAtで昇順ソートされたCard10件
+   */
   async findReviewCards(userId: string, deckId: bigint): Promise<Card[]> {
     const currentDate = new Date(); // 現在時刻
     return await this.prismaService.card.findMany({
@@ -91,5 +97,38 @@ export class CardRepository implements ICardRepository {
         nextReviewAt: 'asc',
       },
     });
+  }
+
+  /**
+   * カードの状態更新
+   *
+   * versionによる複数ワーカー対策を行っている。
+   * 衝突した場合はserviceで例外を投げる仕様。
+   * @returns Card or null
+   */
+  async updateReviewWithVersion(
+    userId: string,
+    cardId: bigint,
+    version: number,
+    data: Prisma.CardUncheckedUpdateInput,
+  ): Promise<Card | null> {
+    const result = await this.prismaService.card.updateMany({
+      where: {
+        deck: { userId },
+        id: cardId,
+        version: version, // 楽観ロック
+      },
+      data: {
+        ...data,
+        version: { increment: 1 }, // 競合検知のため+1して登録
+      },
+    });
+
+    // update失敗時（競合時も含まれる）
+    if (result.count === 0) {
+      return null;
+    }
+    // 更新後のカードを再取得して返却
+    return await this.findByCardId(userId, cardId);
   }
 }

--- a/backend/src/card/dto/review-card.request.ts
+++ b/backend/src/card/dto/review-card.request.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsInt, Min } from 'class-validator';
+import { ReviewRating } from '@memo-anki/shared';
+
+/**
+ * 復習採点リクエスト
+ * - rating: 0=AGAIN, 1=HARD, 2=GOOD, 3=EASY
+ * - version: 楽観ロック用。GET時のCardReviewResponse.versionをそのまま返送する想定
+ */
+export class ReviewCardRequest {
+  @ApiProperty({
+    enum: ReviewRating,
+    enumName: 'ReviewRating',
+    example: ReviewRating.GOOD,
+    description: '0=AGAIN, 1=HARD, 2=GOOD, 3=EASY',
+  })
+  // IsEnum(ReviewRating) はキー名(string)も許してしまうので、明示的に数値値で縛る
+  @IsIn([
+    ReviewRating.AGAIN,
+    ReviewRating.HARD,
+    ReviewRating.GOOD,
+    ReviewRating.EASY,
+  ])
+  rating: ReviewRating;
+
+  @ApiProperty({ example: 0, description: '楽観ロック用のカードバージョン' })
+  @IsInt()
+  @Min(0)
+  version: number;
+}

--- a/backend/src/card/review.service.spec.ts
+++ b/backend/src/card/review.service.spec.ts
@@ -1,0 +1,128 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Test, TestingModule } from '@nestjs/testing';
+import { mockDeep, type DeepMockProxy } from 'vitest-mock-extended';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Card } from '@prisma/client';
+import { CardQueue, CardType, ReviewRating } from '@memo-anki/shared';
+
+import { ReviewService } from './review.service';
+import { ICardRepository } from './card.repository.interface';
+import { DeckService } from '../deck/deck.service';
+import {
+  CardNotFoundException,
+  CardVersionConflictException,
+} from '../common/exceptions/domain.exceptions';
+
+/**
+ * ReviewService.reviewCard の振る舞いに焦点。
+ * applyRating 自体のロジックは apply-rating.spec.ts でカバーするので、ここでは
+ *   - 認可チェックが先に走るか
+ *   - 楽観ロックの結果がそのまま例外に反映されるか
+ * を検証する。
+ */
+describe('ReviewService.reviewCard', () => {
+  let service: ReviewService;
+  let cardRepoMock: DeepMockProxy<ICardRepository>;
+  let deckServiceMock: DeepMockProxy<DeckService>;
+
+  const userId = 'user-123';
+  const cardId = '1';
+
+  // applyRating が触らないカラムも含めたフルカラムのモック
+  const baseCard: Card = {
+    id: 1n,
+    deckId: 10n,
+    name: 'card',
+    type: CardType.NOTE,
+    content: 'c',
+    question: null,
+    answer: null,
+    queue: CardQueue.SHORT, // SHORT×GOODで検証する
+    repetition: 0,
+    interval: 1,
+    easeFactor: 2.5,
+    nextReviewAt: new Date(),
+    version: 3,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    cardRepoMock = mockDeep<ICardRepository>();
+    deckServiceMock = mockDeep<DeckService>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReviewService,
+        { provide: 'ICardRepository', useValue: cardRepoMock },
+        { provide: DeckService, useValue: deckServiceMock },
+      ],
+    }).compile();
+
+    service = module.get<ReviewService>(ReviewService);
+    vi.clearAllMocks();
+  });
+
+  it('正常系: 認可付きでカードを取得し、楽観ロック更新が呼ばれること', async () => {
+    // [試験項目: 採点正常フロー]
+    cardRepoMock.findByCardId.mockResolvedValue(baseCard);
+    cardRepoMock.updateReviewWithVersion.mockResolvedValue({
+      ...baseCard,
+      version: 4,
+    });
+
+    const result = await service.reviewCard({
+      userId,
+      cardId,
+      rating: ReviewRating.GOOD,
+      version: 3,
+    });
+
+    // findByCardIdは userId スコープで呼ばれる（他人のカードは取得不可）
+    expect(cardRepoMock.findByCardId).toHaveBeenCalledWith(userId, 1n);
+    // updateReviewWithVersion は userId / cardId / version / 次状態 を渡す
+    // 次状態の詳細は applyRating 側でテスト済み。ここでは SHORT×GOOD 1回目の
+    // 確定値(queue=SHORT, repetition=1)だけを契約として確認。
+    expect(cardRepoMock.updateReviewWithVersion).toHaveBeenCalledWith(
+      userId,
+      1n,
+      3,
+      expect.objectContaining({
+        queue: CardQueue.SHORT,
+        repetition: 1,
+      }),
+    );
+    expect(result.version).toBe(4);
+  });
+
+  it('異常系: カードが存在しない場合、CardNotFoundException', async () => {
+    // [試験項目: 不在カード]
+    cardRepoMock.findByCardId.mockResolvedValue(null);
+    await expect(
+      service.reviewCard({
+        userId,
+        cardId,
+        rating: ReviewRating.GOOD,
+        version: 3,
+      }),
+    ).rejects.toThrow(CardNotFoundException);
+    // 不在ならupdateも呼ばれない
+    expect(cardRepoMock.updateReviewWithVersion).not.toHaveBeenCalled();
+  });
+
+  it('異常系: 楽観ロック競合(更新0件)で CardVersionConflictException', async () => {
+    // [試験項目: バージョン競合]
+    cardRepoMock.findByCardId.mockResolvedValue(baseCard);
+    // version不一致でnullが返る想定
+    cardRepoMock.updateReviewWithVersion.mockResolvedValue(null);
+
+    await expect(
+      service.reviewCard({
+        userId,
+        cardId,
+        rating: ReviewRating.GOOD,
+        version: 99,
+      }),
+    ).rejects.toThrow(CardVersionConflictException);
+  });
+});

--- a/backend/src/card/review.service.ts
+++ b/backend/src/card/review.service.ts
@@ -1,14 +1,27 @@
-import { Card } from '@prisma/client';
+import { Card, Prisma } from '@prisma/client';
 import { ICardRepository } from './card.repository.interface';
 
 import { Inject, Injectable } from '@nestjs/common';
 import { DeckService } from '../deck/deck.service';
 import { sortReviewQueue } from './sort-review-queue';
-import { DeckNotFoundException } from '../common/exceptions/domain.exceptions';
+import {
+  CardNotFoundException,
+  CardVersionConflictException,
+  DeckNotFoundException,
+} from '../common/exceptions/domain.exceptions';
+import { ReviewRating } from '@memo-anki/shared';
+import { applyRating } from './apply-rating';
 
 export type GetReviewCardDto = {
   deckId: string;
   userId: string;
+};
+
+export type ReviewCardDto = {
+  userId: string;
+  cardId: string;
+  rating: ReviewRating;
+  version: number;
 };
 
 @Injectable()
@@ -20,7 +33,7 @@ export class ReviewService {
   ) {}
   /**
    * 復習キューを取得する
-   * @param dto
+   * @returns ソートされたCard10件
    */
   async findReviewCards(dto: GetReviewCardDto) {
     // PrismaのInput型がないのでdtoのままRepositoryへ渡す。
@@ -37,5 +50,42 @@ export class ReviewService {
     // カードを並び替え
     const sortedQueue: Card[] = sortReviewQueue(reviewCards);
     return sortedQueue;
+  }
+
+  /**
+   * 採点を反映してカードを更新する。
+   * @returns 更新後のCard
+   */
+  async reviewCard(dto: ReviewCardDto): Promise<Card> {
+    const { userId, cardId, rating, version } = dto;
+
+    // 与えられたCardIdが存在するかまたはユーザのものかを検証
+    const card = await this.iCardRepository.findByCardId(
+      userId,
+      BigInt(cardId), // pipesでbigint保証済
+    );
+    if (!card) throw new CardNotFoundException(cardId);
+
+    // 次の状態を計算
+    const appliedCard = applyRating(card, rating);
+
+    // DBに計算した状態を反映
+    const updateInput: Prisma.CardUncheckedUpdateInput = {
+      queue: appliedCard.queue,
+      repetition: appliedCard.repetition,
+      interval: appliedCard.interval,
+      easeFactor: appliedCard.easeFactor,
+      nextReviewAt: appliedCard.nextReviewAt,
+    };
+    const updatedCard = await this.iCardRepository.updateReviewWithVersion(
+      userId,
+      card.id,
+      version,
+      updateInput,
+    );
+
+    // 別ワーカーに先を越されたときnullを返すので例外を投げる
+    if (!updatedCard) throw new CardVersionConflictException(cardId);
+    return updatedCard;
   }
 }

--- a/backend/src/common/exceptions/domain.exceptions.ts
+++ b/backend/src/common/exceptions/domain.exceptions.ts
@@ -66,3 +66,10 @@ export class CardnameAlreadyExistException extends DomainException {
     super(`This Cardname: ${cardname} is already exist.`, HttpStatus.CONFLICT);
   }
 }
+
+// 楽観ロック競合：採点更新時にversionが一致しなかった場合に投げる
+export class CardVersionConflictException extends DomainException {
+  constructor(cardId: string) {
+    super(`CardId: ${cardId} version conflict.`, HttpStatus.CONFLICT);
+  }
+}

--- a/docs/test/card/card-unit-test-plan.md
+++ b/docs/test/card/card-unit-test-plan.md
@@ -1,8 +1,10 @@
 ## 1. 試験実施方針
 
 - **目的**: 実務クオリティを担保しつつ、リソースを最小化するため、ビジネスロジックの要となる「Service」の例外系・条件分岐と、I/Fの入り口である「Controller」のバリデーション・マッピングに絞って実施する。
-- **範囲**: `CardService`, `CardController`
+- **範囲**: `CardService`, `CardController`, `ReviewService`
 - **手法**: Vitest + Prisma Mock (`vitest-mock-extended` 等)
+
+> **関連**: 採点ロジック(`applyRating` / `sm2`)の試験項目は分離している。
 
 ---
 
@@ -26,23 +28,39 @@
 
 ## 3. ParseBigIntIdPipe 試験項目
 
-| テストケース             | 確認事項 (Assertion)                                                      | 備考                |
-| :----------------------- | :------------------------------------------------------------------------ | :------------------ |
-| 正常系: 正常値通過             | 1〜19桁の正整数（先頭非ゼロ）はそのまま返却されること                                          | 境界値 (最小・最大) |
-| バリデーション: 不正フォーマット | 非数字（`abc` 等）・`0`・先頭ゼロ（`01` 等）に対し `InvalidIdFormatException` が飛ぶこと        | 型安全 / 一意性確保 |
-| バリデーション: 桁数超過       | 20桁以上の文字列に対し `InvalidIdFormatException` が飛ぶこと                                   | BigInt上限          |
-| バリデーション: 空文字         | 空文字に対し `InvalidIdFormatException` が飛ぶこと                                             | 空入力              |
+| テストケース                     | 確認事項 (Assertion)                                                                     | 備考                |
+| :------------------------------- | :--------------------------------------------------------------------------------------- | :------------------ |
+| 正常系: 正常値通過               | 1〜19桁の正整数（先頭非ゼロ）はそのまま返却されること                                    | 境界値 (最小・最大) |
+| バリデーション: 不正フォーマット | 非数字（`abc` 等）・`0`・先頭ゼロ（`01` 等）に対し `InvalidIdFormatException` が飛ぶこと | 型安全 / 一意性確保 |
+| バリデーション: 桁数超過         | 20桁以上の文字列に対し `InvalidIdFormatException` が飛ぶこと                             | BigInt上限          |
+| バリデーション: 空文字           | 空文字に対し `InvalidIdFormatException` が飛ぶこと                                       | 空入力              |
 
 ---
 
 ## 4. CardController 試験項目
 
-| メソッド       | テストケース           | 確認事項 (Assertion)                                                           | 備考                 |
-| :------------- | :--------------------- | :----------------------------------------------------------------------------- | :------------------- |
-| **共通**       | ガード確認             | `JwtAuthGuard` がクラスまたはメソッドに付与されていること                      | 認可                 |
-| **createCard** | 正常系: パススルー確認 | Requestの `deckId` (string) がそのまま Service へ渡されること（BigInt 変換は Prisma 直前で行う方針） | I/F整合性            |
-|                | バリデーション         | `type` に `CardType` (NOTE/QUIZ) 以外の値が指定された場合、400エラーとなること | enum バリデーション  |
-|                | 正常系: レスポンス     | 戻り値が `CardResponse` でラップされ、Status 201 を返すこと                    | DTOマッピング        |
-| **getCards**   | 正常系: 配列変換       | Service の戻り値（配列）が、個別に `CardResponse` インスタンス化されていること | マッピング           |
-| **updateCard** | 正常系: 引数伝播       | パスパラメータ `cardId` と `UpdateCardRequest` の内容が Service へ渡されること | I/F整合性            |
-| **deleteCard** | 正常系: 完了レスポンス | 成功時に Status 204 (No Content) を返すこと、`cardId`(Param) が Service へ渡されること | REST準拠             |
+| メソッド       | テストケース                 | 確認事項 (Assertion)                                                                                 | 備考                |
+| :------------- | :--------------------------- | :--------------------------------------------------------------------------------------------------- | :------------------ |
+| **共通**       | ガード確認                   | `JwtAuthGuard` がクラスまたはメソッドに付与されていること                                            | 認可                |
+| **createCard** | 正常系: パススルー確認       | Requestの `deckId` (string) がそのまま Service へ渡されること（BigInt 変換は Prisma 直前で行う方針） | I/F整合性           |
+|                | バリデーション               | `type` に `CardType` (NOTE/QUIZ) 以外の値が指定された場合、400エラーとなること                       | enum バリデーション |
+|                | 正常系: レスポンス           | 戻り値が `CardResponse` でラップされ、Status 201 を返すこと                                          | DTOマッピング       |
+| **getCards**   | 正常系: 配列変換             | Service の戻り値（配列）が、個別に `CardResponse` インスタンス化されていること                       | マッピング          |
+| **updateCard** | 正常系: 引数伝播             | パスパラメータ `cardId` と `UpdateCardRequest` の内容が Service へ渡されること                       | I/F整合性           |
+| **deleteCard** | 正常系: 完了レスポンス       | 成功時に Status 204 (No Content) を返すこと、`cardId`(Param) が Service へ渡されること               | REST準拠            |
+| **reviewCard** | 正常系: 採点パススルー       | `userId` / `cardId`(Param) / `rating` / `version` が `ReviewService.reviewCard` に渡されること       | I/F整合性           |
+|                | 正常系: レスポンス型         | 戻り値が `CardReviewResponse` でラップされ、楽観ロック用の `version` が含まれること                  | 楽観ロック契約      |
+|                | バリデーション: rating範囲外 | `rating` が `0-3` 以外（例: `4`）の場合、400エラーとなること                                         | enum バリデーション |
+|                | バリデーション: 負のversion  | `version` が負の数の場合、400エラーとなること                                                        | 楽観ロック整合性    |
+
+---
+
+## 5. ReviewService 試験項目
+
+| メソッド       | テストケース           | 確認事項 (Assertion)                                                                                                                                                                           | 優先理由             |
+| :------------- | :--------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------- |
+| **reviewCard** | 正常系: 採点正常フロー | `findByCardId(userId, ...)` で認可付き取得後、`updateReviewWithVersion` に `userId` / `cardId` / `version` / 次状態(applyRating結果) が渡されること。戻り値の `version` が更新後の値であること | 採点フロー全体の担保 |
+|                | 異常系: 不在カード     | `findByCardId` が `null` を返した場合、`CardNotFoundException` が飛び、`updateReviewWithVersion` は呼ばれないこと                                                                              | 認可・整合性         |
+|                | 異常系: 楽観ロック競合 | `updateReviewWithVersion` が `null` (更新0件) を返した場合、`CardVersionConflictException` (HTTP 409) が飛ぶこと                                                                               | 楽観ロックの担保     |
+
+> **補足**: 次状態の中身（queue/repetition/interval/easeFactor/nextReviewAt）の正しさは `applyRating` 側でテストする。


### PR DESCRIPTION
## 概要
Review後のCardを受け取り、状態を変化させてDBに反映させるAPIを作成した。

## 詳細
ServiceとRepositoryで所有者チェックとカードの存在確認をしている。
Versionによる複数ワーカ対策を施している。
Controllerの返却値としてCardreviewResponseを返しているが今のところフロントでつかう予定はない。一応残しておく。
