### PR TITLE
feat: 復習完了画面を作成

### DIFF
--- a/frontend/app/(main)/decks/[deckId]/review/complete/page.tsx
+++ b/frontend/app/(main)/decks/[deckId]/review/complete/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import Link from 'next/link';
+
+export default function ReviewCompletePage() {
+  return (
+    <div className="flex-1 bg-gray-50 flex items-center justify-center">
+      <div className="w-full max-w-[1536px] mx-auto px-6 py-12">
+        {/* 完了メッセージ用の白いパネル */}
+        <section
+          className="bg-white border border-gray-200 rounded-lg mx-auto px-8 py-14 text-center"
+          style={{ maxWidth: 520 }}
+        >
+          {/* 成功アイコン（チェックマーク） */}
+          <div
+            className="mx-auto mb-5 flex items-center justify-center rounded-full"
+            style={{
+              width: 72,
+              height: 72,
+              background: '#f5f3ff',
+              border: '1.5px solid #ddd6fe',
+            }}
+            aria-hidden="true"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="#4f2bdf"
+              strokeWidth={2.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              style={{ width: 32, height: 32 }}
+            >
+              <polyline points="4 12.5 10 18.5 20 6.5" />
+            </svg>
+          </div>
+
+          {/* メインメッセージ */}
+          <h1 className="text-[22px] font-bold text-gray-900 mb-2">
+            お疲れさまでした。
+          </h1>
+          <p className="text-[13px] text-gray-500 mb-8">
+            このデッキの復習はすべて完了しました。
+          </p>
+
+          {/* デッキ一覧へ戻るボタン */}
+          <Link href="/decks" className="btn btn-primary">
+            デッキ一覧に戻る
+          </Link>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(main)/decks/page.tsx
+++ b/frontend/app/(main)/decks/page.tsx
@@ -21,8 +21,9 @@ export default function DeckListPage() {
   const [open, setOpen] = useState(false);
 
   // CRUD(可読性のためにラップしている)
-  const handleReview = () => {
-    console.log('復習:link');
+  const handleReview = (deckId: string) => {
+    // 一時的に配置
+    router.push(`/decks/${deckId}/review/complete`);
   };
   const handleEdit = (deckId: string) => {
     router.push(`/decks/${deckId}`);


### PR DESCRIPTION
## 概要
復習完了画面を作成した。
## 詳細
中央に完了メッセージとデッキ一覧へ戻るボタンを配置している。非常にシンプルにした。
復習したカード数などの統計をつけるか迷ったが時間ができてからでいいと考えた。

---
Closes #104 