### PR TITLE
Fix/pagelayout and editmodals

### DIFF
--- a/frontend/app/(main)/decks/[deckId]/page.tsx
+++ b/frontend/app/(main)/decks/[deckId]/page.tsx
@@ -70,7 +70,8 @@ export default function CardListPage() {
   if (isError)
     return <div>エラーが発生しました: {(error as Error).message}</div>;
   return (
-    <main className="flex-1 bg-gray-50">
+    // decks/layout.tsx の main(flex-1) に乗っかって残り空間を埋める
+    <div className="flex-1 bg-gray-50 text-gray-800">
       <div className="max-w-[1536px] mx-auto px-6 py-8">
         <section className="bg-white border border-gray-200 rounded-lg overflow-hidden">
           <CardListPageHeader
@@ -113,6 +114,6 @@ export default function CardListPage() {
           onSave={handleUpdateCard}
         />
       )}
-    </main>
+    </div>
   );
 }

--- a/frontend/app/(main)/decks/page.tsx
+++ b/frontend/app/(main)/decks/page.tsx
@@ -41,43 +41,41 @@ export default function DeckListPage() {
     return <div>エラーが発生しました: {(error as Error).message}</div>;
 
   return (
-    <div className="flex-1 flex flex-col bg-white text-gray-800">
-      {/* メイン領域（薄いグレーの背景） */}
-      <main className="flex-1 bg-gray-50">
-        <div className="max-w-[1536px] mx-auto px-6 py-8">
-          {/* 白いパネルの中にタイトルとグリッドを置く */}
-          <section className="bg-white border border-gray-200 rounded-lg px-8 py-7">
-            {/* タイトル + ボタンを横並びに */}
-            <div className="flex items-center justify-between mb-5">
-              <h1 className="text-[20px] font-bold">デッキ一覧</h1>
-              <button
-                onClick={() => {
-                  setOpen(true);
-                }}
-                className="mt-4 w-25 h-9 rounded-md bg-indigo-600 hover:bg-indigo-800 text-white text-sm font-semibold"
-              >
-                ＋ 新規作成
-              </button>
-            </div>
+    // decks/layout.tsx の main(flex-1) に乗っかって残り空間を埋める。
+    <div className="flex-1 bg-gray-50 text-gray-800">
+      <div className="max-w-[1536px] mx-auto px-6 py-8">
+        {/* 白いパネルの中にタイトルとグリッドを置く */}
+        <section className="bg-white border border-gray-200 rounded-lg px-8 py-7">
+          {/* タイトル + ボタンを横並びに */}
+          <div className="flex items-center justify-between mb-5">
+            <h1 className="text-[20px] font-bold">デッキ一覧</h1>
+            <button
+              onClick={() => {
+                setOpen(true);
+              }}
+              className="mt-4 w-25 h-9 rounded-md bg-indigo-600 hover:bg-indigo-800 text-white text-sm font-semibold"
+            >
+              ＋ 新規作成
+            </button>
+          </div>
 
-            <div className="border-t-[1px] border-gray-200 mb-8"></div>
+          <div className="border-t-[1px] border-gray-200 mb-8"></div>
 
-            <DeckGrid
-              decks={decks ?? []}
-              onReview={handleReview}
-              onEdit={handleEdit}
-              onDelete={handleDelete}
-            />
-          </section>
-        </div>
-        <DeckCreateModal
-          open={open}
-          onClose={() => {
-            setOpen(false);
-          }}
-          onCreate={handleCreate}
-        />
-      </main>
+          <DeckGrid
+            decks={decks ?? []}
+            onReview={handleReview}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+          />
+        </section>
+      </div>
+      <DeckCreateModal
+        open={open}
+        onClose={() => {
+          setOpen(false);
+        }}
+        onCreate={handleCreate}
+      />
     </div>
   );
 }

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,28 +1,13 @@
-// /login = ログイン / 新規登録画面。
-//
-// 役割:
-//   - 中央にロゴ + タブ + フォームのカードを表示する
-//   - 下部にフッター（© memo-anki）を表示する
-//
-// このページは (main) レイアウトに属さないため、共通ヘッダーは表示しない想定です。
-// ログイン中の場合は middleware 等で /decks にリダイレクトしてください。
-
 import AuthCard from '@/features/auth/components/AuthCard';
 
 export default function LoginPage() {
   return (
-    <div className="min-h-screen flex flex-col bg-[#f7f7f8] text-gray-800">
+    // body(min-h-screen flex flex-col) に乗っかって残り空間を埋める
+    <div className="flex-1 flex flex-col bg-[#f7f7f8] text-gray-800">
       {/* 中央カード */}
       <main className="flex-1 flex items-center justify-center px-4 py-12">
         <AuthCard />
       </main>
-
-      {/* Footer（共通） */}
-      <footer className="border-t border-gray-200">
-        <div className="text-center text-[12px] text-gray-500 py-3">
-          © 2026 memo-anki | Created by araki
-        </div>
-      </footer>
     </div>
   );
 }

--- a/frontend/features/card/components/CardEditModal.tsx
+++ b/frontend/features/card/components/CardEditModal.tsx
@@ -1,4 +1,7 @@
 'use client';
+// React Compiler が react-hook-form の register をメモ化して onChange が
+// 機能しなくなる問題の回避。このファイルだけ Compiler の最適化対象から外す。
+'use no memo';
 
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';

--- a/frontend/features/deck/components/DeckUpdateModal.tsx
+++ b/frontend/features/deck/components/DeckUpdateModal.tsx
@@ -1,4 +1,6 @@
 'use client';
+// cardEditModalに詳細記載
+'use no memo';
 
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';


### PR DESCRIPTION
## 概要
- 画面を作るうえで既存のページ構成に不具合があったため修正した。
- カード編集バグ修正

## 詳細
- ページ構成について
	- decks/layout.tsxにてmainを配置していた。しかし、各ファイルで独自にmainを設定していたため二重でmainができていた。
	- flex構造が二重になっていたため、decks/layout.tsxのmainを親、各ページを子として再構築した。
- カード編集バグについて
カード編集処理についてコード自体は正しいはずが更新されないバグが発生した。
API通信の有無と送信しているPUTデータを確認したところ更新されていないdataが送られていた。
しかし、RHFの書き方に問題は見当たらない。AIに投げたところ、ReactCompilerのメモ化の仕様によって
onChangeが機能しなくなるバグのようだ。ひとまず編集モーダルはmemo化の対象から外すことによって
更新されたのが確認できた。
