### PR TITLE
Feat/review screen api

### DIFF
--- a/frontend/app/(main)/decks/[deckId]/review/page.tsx
+++ b/frontend/app/(main)/decks/[deckId]/review/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 
 import { CardType } from '@memo-anki/shared';
@@ -8,57 +8,78 @@ import { CardType } from '@memo-anki/shared';
 import ReviewLayout from '@/features/review/components/ReviewLayout';
 import ReviewNoteBody from '@/features/review/components/ReviewNoteBody';
 import ReviewQuizBody from '@/features/review/components/ReviewQuizBody';
-import { useReviewQueue } from '@/features/review/hooks/useReviewQueue';
-import { buildCardDetail } from '@/features/card/utils/cardView';
-// import { useQuery, useQueryClient } from '@tanstack/react-query';
-// import { components } from '@memo-anki/shared';
+import { useReviewCards } from '@/features/review/hooks/useReviewQueue';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { components } from '@memo-anki/shared';
 
-// type Deck = components['schemas']['DeckResponse'];
+/* 
+  復習画面内のカード部分を入れ替えることによって復習の流れを表現
+  つまりCSR。REST。
+*/
+type Deck = components['schemas']['DeckResponse'];
 
 export default function ReviewPage() {
-  const router = useRouter();
-
+  /**
+   * 状態管理・取得
+   */
   // urlからパスパラメータ取得
+  const router = useRouter();
   const params = useParams<{ deckId: string }>();
-  const deckId = Number(params.deckId);
+  const deckId = params.deckId;
 
-  // // キャッシュからdeckを取得（fetchはせずキャッシュ更新を購読）
-  // const queryClient = useQueryClient();
-  // const { data: decks } = useQuery<Deck[]>({
-  //   queryKey: ['decks'],
-  //   queryFn: () =>
-  //     Promise.resolve(queryClient.getQueryData<Deck[]>(['decks']) ?? []),
-  //   enabled: false,
-  // });
-  // const deck = decks?.find((deck) => deck.id === deckId);
+  // キャッシュからdeckを取得（fetchはせずキャッシュ更新を購読）
+  const queryClient = useQueryClient();
+  const { data: decks } = useQuery<Deck[]>({
+    queryKey: ['decks'],
+    queryFn: () =>
+      Promise.resolve(queryClient.getQueryData<Deck[]>(['decks']) ?? []),
+    enabled: false,
+  });
+  const deck = decks?.find((deck) => deck.id === deckId); // 将来個別デッキの取得api追加する
 
-  const { current, finished, rating } = useReviewQueue(deckId);
-
-  // デッキ名
-  const [deckName] = useState('デッキ名');
-
-  // QUIZ 中で「解答を表示済みか」を子から受け取り、
-  // 評価ボタンの活性/非活性を切り替えるのに使う。
+  // Quiz内の回答表示状態を管理
   const [answerShown, setAnswerShown] = useState(false);
 
-  // すべて完了 → 完了画面へ
-  if (finished) {
-    router.push(`/decks/${deckId}/review/complete`);
-    return null;
-  }
+  // 現在の復習状態を取り出す
+  const { current, finished, rating, isLoading, isError, error } =
+    useReviewCards(deckId);
 
-  // ロード中 / カード未取得
+  // すべて完了 → レンダリング後に完了画面へ遷移
+  // 採点ボタンを連打すると復習画面のレンダリング中に完了画面への
+  // router.pushが呼ばれエラーになる
+  useEffect(() => {
+    if (finished) {
+      router.push(`/decks/${deckId}/review/complete`);
+    }
+  }, [finished, router, deckId]);
+
+  /**
+   * 状態によるreturn分岐
+   */
+
+  // ロード中
+  if (isLoading) return <div>読み込み中...</div>;
+
+  // エラー発生
+  if (isError)
+    return <div>エラーが発生しました: {(error as Error).message}</div>;
+
+  // すべて完了（useEffectで遷移するまでの間、何も表示しない）
+  if (finished) return null;
+
+  // 復習対象カードが0件
   if (!current) {
     return (
-      <main className="flex-1 bg-gray-50">
+      <div className="flex-1 bg-gray-50">
         <div className="max-w-[860px] mx-auto px-6 py-16 text-center text-gray-400 text-[13px]">
-          復習カードを読み込み中…
+          復習するカードはありません
         </div>
-      </main>
+      </div>
     );
   }
 
-  const cardName = buildCardDetail(current);
+  // 復習カードが存在
+
   // API レスポンスの type（0 | 1）を CardType enum にキャストする
   const cardType = current.type as CardType;
   const isQuiz = cardType === CardType.QUIZ;
@@ -66,20 +87,24 @@ export default function ReviewPage() {
   return (
     <ReviewLayout
       deckId={deckId}
-      deckName={deckName}
-      cardName={cardName}
+      deckName={deck?.name ?? ''}
+      cardName={current.name}
       cardType={cardType}
-      onRating={rating}
+      onRating={(r) => {
+        // カード切り替え前に回答表示状態をリセットする
+        setAnswerShown(false);
+        rating(r);
+      }}
+      // quizかつ回答が表示されているときtrue(ボタン有効化)
       ratingDisabled={isQuiz && !answerShown}
     >
       {/* children */}
       {isQuiz ? (
-        // key={current.id} でカード切り替え時にコンポーネントを再マウントし、shown をリセットする
         <ReviewQuizBody
-          key={current.id}
           question={current.question ?? ''}
           answer={current.answer ?? ''}
-          onAnswerShownChange={setAnswerShown}
+          shown={answerShown}
+          onAnswerShown={setAnswerShown}
         />
       ) : (
         // ただcontentを表示するだけ

--- a/frontend/app/(main)/decks/page.tsx
+++ b/frontend/app/(main)/decks/page.tsx
@@ -22,8 +22,7 @@ export default function DeckListPage() {
 
   // CRUD(可読性のためにラップしている)
   const handleReview = (deckId: string) => {
-    // 一時的に配置
-    router.push(`/decks/${deckId}/review/complete`);
+    router.push(`/decks/${deckId}/review`);
   };
   const handleEdit = (deckId: string) => {
     router.push(`/decks/${deckId}`);

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -23,13 +23,13 @@ export default function Header({ userName }: HeaderProps) {
 
   return (
     <header className="w-full border-b border-gray-200">
-      <div className="flex items-center justify-between px-5 py-4.5">
+      <div className="bg-white flex items-center justify-between px-5 py-4.5">
         <span className="bg-slate-900 text-white font-bold px-2.5 py-1 rounded-md text-[13px]">
           memo-anki
         </span>
         <div className="flex items-center gap-3">
           <span className="text-[13px] text-gray-700">{userName}</span>
-          <button onClick={handleLogout} className="btn btn-ghost btn-xs">
+          <button onClick={handleLogout} className="btn btn-info btn-xs">
             ログアウト
           </button>
         </div>

--- a/frontend/features/review/components/ReviewLayout.tsx
+++ b/frontend/features/review/components/ReviewLayout.tsx
@@ -9,7 +9,7 @@ import CardTypeBadge from '@/features/card/components/CardTypeBadge';
 import ReviewRatingButtons from './ReviewRatingButtons';
 
 type ReviewLayoutProps = {
-  deckId: number;
+  deckId: string;
   deckName: string;
   cardName: string;
   cardType: CardType;

--- a/frontend/features/review/components/ReviewQuizBody.tsx
+++ b/frontend/features/review/components/ReviewQuizBody.tsx
@@ -1,32 +1,27 @@
 'use client';
 
-import { useState } from 'react';
-
-// カード切り替え時のリセットは page 側で key={cardId} を渡すことで行う。
-// key が変わると React がコンポーネントを再マウントし、shown が自動で false に戻る。
+// カード切り替え時の shown リセットは page 側の onRating ハンドラで行う。
 type ReviewQuizBodyProps = {
   question: string;
   answer: string;
-  onAnswerShownChange: (shown: boolean) => void;
+  shown: boolean;
+  onAnswerShown: (shown: boolean) => void;
 };
 
 export default function ReviewQuizBody({
   question,
   answer,
-  onAnswerShownChange,
+  shown,
+  onAnswerShown,
 }: ReviewQuizBodyProps) {
-  const [shown, setShown] = useState(false);
-
   // 解答を表示し、親に通知する
   const handleShow = () => {
-    setShown(true);
-    onAnswerShownChange(true);
+    onAnswerShown(true);
   };
 
   // 解答を非表示にし、親に通知する
   const handleHide = () => {
-    setShown(false);
-    onAnswerShownChange(false);
+    onAnswerShown(false);
   };
 
   return (
@@ -47,7 +42,7 @@ export default function ReviewQuizBody({
             <button
               type="button"
               onClick={handleHide}
-              className="btn btn-outline btn-sm h-[42px] px-6 text-[14px] font-semibold"
+              className="btn text-black btn-outline btn-sm h-[42px] px-6 text-[14px] font-semibold"
             >
               解答を非表示
             </button>
@@ -58,7 +53,7 @@ export default function ReviewQuizBody({
           <button
             type="button"
             onClick={handleShow}
-            className="btn btn-outline h-[42px] px-6 text-[14px] font-semibold"
+            className="btn text-black btn-outline h-[42px] px-6 text-[14px] font-semibold"
           >
             解答を表示
           </button>

--- a/frontend/features/review/hooks/useReviewMutation.ts
+++ b/frontend/features/review/hooks/useReviewMutation.ts
@@ -1,0 +1,42 @@
+import { apiClient } from '@/lib/api/client';
+import { useMutation } from '@tanstack/react-query';
+import { components } from '@memo-anki/shared';
+import { HttpStatus } from '@/lib/api/statusCodes';
+import { toast } from 'sonner';
+import { HttpError } from '@/lib/api/httpError';
+
+type ReviewCardRequest = components['schemas']['ReviewCardRequest'];
+type Card = components['schemas']['CardReviewResponse'];
+
+export const useReviewMutation = () => {
+  const handleError = (err: unknown) => {
+    if (err instanceof HttpError) {
+      switch (err.statusCode) {
+        case HttpStatus.BAD_REQUEST:
+          toast.error('正しい形式で入力してください');
+          break;
+        case HttpStatus.CONFLICT:
+          toast.error('採点で競合が発生しました。');
+          break;
+        case HttpStatus.NOT_FOUND:
+          toast.error('復習すべきカードがありません');
+          break;
+        default:
+          toast.error('サーバーエラーが発生しました');
+      }
+    } else {
+      toast.error('ネットワークエラーが発生しました');
+    }
+  };
+
+  /** 採点 */
+  const reviewedCard = useMutation<Card, unknown, [string, ReviewCardRequest]>({
+    mutationFn: ([cardId, body]) =>
+      apiClient(`/card/${cardId}/review`, 'POST', body) as Promise<Card>,
+    // テンポ重視のため成功時にtoastは出さない仕様
+    onError: handleError,
+  });
+  return {
+    reviewedCard,
+  };
+};

--- a/frontend/features/review/hooks/useReviewQueue.ts
+++ b/frontend/features/review/hooks/useReviewQueue.ts
@@ -58,11 +58,15 @@ export function useReviewCards(deckId: string): ReviewQueueState {
     rating: (r) => {
       // page.tsxでも防御しているが二重でガード
       if (!current) return;
-      reviewedCard.mutate([
+      // 前回の採点が完了するまで受け付けない（二重送信を防ぐ）
+      if (reviewedCard.isPending) return;
+      // テンポ優先のためAPI完了を待たずに次のカードへ進める
+      setIndex((i) => i + 1);
+      // 次フェーズでshouldFetch/mergeQueueをawaitで繋ぐ準備としてmutateAsyncを使用する
+      void reviewedCard.mutateAsync([
         current.id,
         { rating: r, version: current.version },
       ]);
-      setIndex((i) => i + 1);
     },
   };
 }

--- a/frontend/features/review/hooks/useReviewQueue.ts
+++ b/frontend/features/review/hooks/useReviewQueue.ts
@@ -1,32 +1,68 @@
+import { useState } from 'react';
+import { apiClient } from '@/lib/api/client';
 import { type components, ReviewRating } from '@memo-anki/shared';
+import { useQuery } from '@tanstack/react-query';
+import { useReviewMutation } from './useReviewMutation';
 
-type Card = components['schemas']['CardResponse'];
+type Card = components['schemas']['CardReviewResponse'];
 
 export type ReviewQueueState = {
   /** 現在表示中のカード。完了/ロード中は null。 */
   current: Card | null;
-  /** 0-indexed の現在位置 */
-  index: number;
-  /** 復習対象の総数 */
-  total: number;
-  /** すべて完了したか */
   finished: boolean;
   isLoading: boolean;
+  isError: boolean;
   error: unknown;
   /** 採点して次のカードへ進める */
   rating: (rating: ReviewRating) => void;
 };
 
-export function useReviewQueue(deckId: number): ReviewQueueState {
-  // 追加
-  console.log('[stub] useReviewQueue', deckId);
+/**
+ * ReviewQueueの状態を管理
+ */
+export function useReviewCards(deckId: string): ReviewQueueState {
+  // setIndex を呼ぶことで再レンダリングをトリガーし、表示カードを切り替える
+  const [index, setIndex] = useState(0);
+
+  // 採点APIの呼び出し
+  const { reviewedCard } = useReviewMutation();
+
+  // 復習対象カードを初回のみ取得する（採点後の再fetchは次フェーズで実装）
+  const {
+    data: cards = [],
+    isLoading,
+    isError,
+    error,
+  } = useQuery<Card[]>({
+    queryKey: ['reviewQueue', deckId],
+    queryFn: async () =>
+      (await apiClient(`/card/review?deckId=${deckId}`, 'GET')) as Card[],
+
+    // fetchタイミングは後で手動制御するためTanStack Queryの自動再fetchを無効化する。
+    staleTime: Infinity,
+  });
+
+  // 現在表示中のカード（末尾を超えたら null）
+  const current = cards[index] ?? null;
+
+  // ロードしているときは完了ではない。取得したキューが0件の時は完了。indexが配列の最大値の時は完了。
+  const finished = !isLoading && cards.length > 0 && index >= cards.length;
+
   return {
-    current: null,
-    index: 0,
-    total: 0,
-    finished: false,
-    isLoading: false,
-    error: null,
-    rating: (r) => console.log('[stub] rating', r),
+    current,
+    finished,
+    isLoading,
+    isError,
+    error,
+    // 採点APIを呼び、次のカードへ進める
+    rating: (r) => {
+      // page.tsxでも防御しているが二重でガード
+      if (!current) return;
+      reviewedCard.mutate([
+        current.id,
+        { rating: r, version: current.version },
+      ]);
+      setIndex((i) => i + 1);
+    },
   };
 }


### PR DESCRIPTION
## 概要
復習画面のAPI接続部分を作成した。
これで復習機能自体は動作する。今後はパフォーマンス改善のための最小フェッチ間隔や、残り3カードで強制fetchなどを実装する。

## 詳細
採点終了ごとにfetchする構造にしている。
- keyによる回答の表示・非表示の切り替えやめて、useStateを用いてpage.tsxで一元的に管理するように変更
- routerの更新をuseEffect内で行うことでボタン連打によるレンダリング重複エラーを回避
- useReviewMutationではテンポを重視して、successを排除。
- useReviewQueueでは復習状態を管理する関数として再構築。
  - 不要なカラムを排除
  - useStateによる配列のindex管理を行いCSR・RESTを実現
  - useQueryでRVキューの状態を管理しているがのちにuseStateに委譲