### PR TITLE
Feat/review fetch optimization

### DIFF
--- a/frontend/features/review/api/getReviewQueue.ts
+++ b/frontend/features/review/api/getReviewQueue.ts
@@ -1,0 +1,11 @@
+import { apiClient } from '@/lib/api/client';
+import { type components } from '@memo-anki/shared';
+
+type Card = components['schemas']['CardReviewResponse'];
+
+/**
+ * 復習キューを取得する関数
+ */
+export async function fetchReviewQueue(deckId: string): Promise<Card[]> {
+  return (await apiClient(`/card/review?deckId=${deckId}`, 'GET')) as Card[];
+}

--- a/frontend/features/review/hooks/useReviewQueue.ts
+++ b/frontend/features/review/hooks/useReviewQueue.ts
@@ -1,8 +1,12 @@
-import { useState } from 'react';
-import { apiClient } from '@/lib/api/client';
-import { type components, ReviewRating } from '@memo-anki/shared';
+'use client';
+
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { type components, ReviewRating } from '@memo-anki/shared';
 import { useReviewMutation } from './useReviewMutation';
+import { shouldFetch } from '../lib/shouldFetch';
+import { mergeQueue } from '../lib/mergeQueue';
+import { fetchReviewQueue } from '../api/getReviewQueue';
 
 type Card = components['schemas']['CardReviewResponse'];
 
@@ -14,59 +18,96 @@ export type ReviewQueueState = {
   isError: boolean;
   error: unknown;
   /** 採点して次のカードへ進める */
-  rating: (rating: ReviewRating) => void;
+  rating: (rating: ReviewRating) => Promise<void>;
 };
 
 /**
  * ReviewQueueの状態を管理
  */
 export function useReviewCards(deckId: string): ReviewQueueState {
-  // setIndex を呼ぶことで再レンダリングをトリガーし、表示カードを切り替える
-  const [index, setIndex] = useState(0);
-
-  // 採点APIの呼び出し
-  const { reviewedCard } = useReviewMutation();
-
-  // 復習対象カードを初回のみ取得する（採点後の再fetchは次フェーズで実装）
+  // 初回fetchはuseQueryに任せる(ロード状態・エラー状態の管理はTanStack Queryの責務)
   const {
-    data: cards = [],
+    data: initialQueue,
+    dataUpdatedAt,
     isLoading,
     isError,
     error,
   } = useQuery<Card[]>({
     queryKey: ['reviewQueue', deckId],
-    queryFn: async () =>
-      (await apiClient(`/card/review?deckId=${deckId}`, 'GET')) as Card[],
-
-    // fetchタイミングは後で手動制御するためTanStack Queryの自動再fetchを無効化する。
-    staleTime: Infinity,
+    queryFn: () => fetchReviewQueue(deckId),
+    staleTime: Infinity, // データを「古い」と判定させない=自動再fetchしない
+    gcTime: 0, // 画面離脱時にキャッシュ破棄
+    refetchOnWindowFocus: false, // ウィンドウ復帰時に再fetchしない
   });
 
-  // 現在表示中のカード（末尾を超えたら null）
-  const current = cards[index] ?? null;
+  // 採点・マージで独自にキューを変形するためローカルstateで上書きする
+  // 初回はnullで二回目以降はuseQueryで取得したqueueをここに代入
+  const [localQueue, setLocalQueue] = useState<Card[] | null>(null);
 
-  // ロードしているときは完了ではない。取得したキューが0件の時は完了。indexが配列の最大値の時は完了。
-  const finished = !isLoading && cards.length > 0 && index >= cards.length;
+  // 再レンダリング不要な値はrefで管理する
+  /** 最終fetch時刻 この値が20sを累積で超えたら再fetch */
+  const lastFetchAt = useRef<number>(0);
+  const isRating = useRef(false); // 採点フラグ(連打送信防止)
 
-  return {
-    current,
-    finished,
-    isLoading,
-    isError,
-    error,
-    // 採点APIを呼び、次のカードへ進める
-    rating: (r) => {
-      // page.tsxでも防御しているが二重でガード
-      if (!current) return;
-      // 前回の採点が完了するまで受け付けない（二重送信を防ぐ）
-      if (reviewedCard.isPending) return;
-      // テンポ優先のためAPI完了を待たずに次のカードへ進める
-      setIndex((i) => i + 1);
-      // 次フェーズでshouldFetch/mergeQueueをawaitで繋ぐ準備としてmutateAsyncを使用する
-      void reviewedCard.mutateAsync([
-        current.id,
-        { rating: r, version: current.version },
-      ]);
+  // 初回fetch完了時刻をuseQueryのlastFetchAtに同期（累積時間で判断）
+  useEffect(() => {
+    if (dataUpdatedAt) {
+      lastFetchAt.current = dataUpdatedAt;
+    }
+  }, [dataUpdatedAt]);
+
+  const { reviewedCard } = useReviewMutation();
+
+  /** 表示用のキュー: 初回はinitialQueue、二回目以降はlocalQueue */
+  const queue = localQueue ?? initialQueue ?? [];
+  /** 現在表示中のカード */
+  const current = queue[0] ?? null;
+  // ロード完了後にキューが空になった時点で完了
+  const finished = !isLoading && !isError && queue.length === 0;
+
+  // ReviewLayoutが再レンダリングされるとratingが再生成され参照がずれる。
+  // そのためuseCallbackで参照ずれを防止。
+  /** 採点時に呼び出される関数 */
+  const rating = useCallback(
+    async (r: ReviewRating): Promise<void> => {
+      if (queue.length === 0) return;
+      if (isRating.current) return; // 採点ロック確認
+      isRating.current = true; // 採点ロック設定
+
+      const head = queue[0];
+
+      // 先頭のCard以外取り出してstateに保存
+      const nextQueue = queue.slice(1);
+      // 次のqueueを待たず次のカードへ進める
+      setLocalQueue(nextQueue);
+
+      try {
+        // 採点API呼び出し
+        await reviewedCard.mutateAsync([
+          head.id,
+          { rating: r, version: head.version },
+        ]);
+
+        // fetch条件
+        if (shouldFetch(nextQueue, lastFetchAt.current)) {
+          try {
+            const newCards = await fetchReviewQueue(deckId);
+            //mergeQueueで合成したQueueを保存（関数形式によりawaitによる参照ずれを防ぐ）
+            setLocalQueue((prev) => mergeQueue(prev ?? nextQueue, newCards));
+          } finally {
+            lastFetchAt.current = Date.now();
+          }
+        }
+      } catch {
+        // 握りつぶす。
+        // 採点失敗: useReviewMutationのonErrorがtoastを表示する
+        // fetch失敗: サイレントに継続する(残存キューで復習を続ける)
+      } finally {
+        isRating.current = false;
+      }
     },
-  };
+    [queue, deckId, reviewedCard],
+  );
+
+  return { current, finished, isLoading, isError, error, rating };
 }

--- a/frontend/features/review/lib/mergeQueue.ts
+++ b/frontend/features/review/lib/mergeQueue.ts
@@ -1,0 +1,16 @@
+import { type components } from '@memo-anki/shared';
+
+type Card = components['schemas']['CardReviewResponse'];
+/**
+ * 配列の先頭を除き、配列を置き換え
+ * @param currentQueue
+ * @param nextQueue
+ * @returns
+ */
+export function mergeQueue(currentQueue: Card[], nextQueue: Card[]): Card[] {
+  if (currentQueue.length === 0) return nextQueue;
+  const head = currentQueue[0];
+  // nextQueueから先頭を排除
+  const rest = nextQueue.filter((c) => c.id !== head.id);
+  return [head, ...rest];
+}

--- a/frontend/features/review/lib/shouldFetch.ts
+++ b/frontend/features/review/lib/shouldFetch.ts
@@ -1,0 +1,35 @@
+import { type components } from '@memo-anki/shared';
+
+type Card = components['schemas']['CardReviewResponse'];
+
+/** 最小fetch間隔 = 20秒 */
+const MIN_FETCH_INTERVAL = 20000;
+/** fetch強制値 */
+const FORCE_FETCH_THRESHOLD = 3;
+
+/**
+ * fetchのタイミング制御によりパフォーマンス改善
+ *
+ * 採点ごとにfetchを行うと、サーバーの負荷が大きくなる。
+ * そのため、以下の二つの仕様を設ける。
+ * - 最小fetch間隔：高速で回答を行った際にfetchせず次のqueueを閲覧する。
+ * - fetch強制値：残りQueueが３件になった時に強制的にfetchする。
+ * @param remainingQueue 先頭を削除したQueue
+ * @param lastFetchAt
+ * @returns
+ */
+export function shouldFetch(
+  remainingQueue: Card[],
+  lastFetchAt: number,
+): boolean {
+  const remaining = remainingQueue.length;
+
+  // セーフティネット: 残り3件以下なら無条件でfetch
+  if (remaining <= FORCE_FETCH_THRESHOLD) return true;
+
+  // 通常: 前回fetchから20秒以上経過していればfetch
+  const elapsed = Date.now() - lastFetchAt;
+  if (elapsed >= MIN_FETCH_INTERVAL) return true;
+
+  return false;
+}


### PR DESCRIPTION
## 概要
復習キューの取得ロジックの最適化を行った。
採点後に毎回fetchする仕様だったためサーバー負荷が大きかった。これを解決するために主に二つの対策を講じた。
- 高速回答時に採点タイミングのfetchをパスする、最小fetch間隔の導入
- 最小フェッチ間隔の穴を埋める、強制fetch閾値の導入

## 詳細
- なぜ二つの対策が必要か → 2つのルールは役割が異なる
  - 最小fetch間隔: 「テンポが速い時にfetchを間引く」ための仕組み
  - 強制fetch閾値: 「間引きすぎてキューが枯渇するのを防ぐ」予防策

両者が補完関係にある。間引きルールだけだと枯渇リスクがあり、強制ルールだけだと高速回答時に毎回fetchしてしまう。
- Fetch方法について
初回と二回目以降で二つの復習キュー取得がある。
初回はuseQueryを使うことでローディング・エラー状態を管理。２回目以降はfetchでキューを取得してuseStateで管理する。
これにより、useQueryのisLoading, isErrorなどが使えてuseStateの管理負担が軽減することができる。二回目以降のfetchは失敗しても、今あるQueueを進めればいいのでローディング・エラー状態を管理する必要がない。
また、二回目以降でもuseQueryでfetchを行わない理由は、tanstackqueryのメリットが生かせないことと、Queueを変形するロジックがあり、tanstackqueryのサーバーの正しい値を管理するという思想から外れると判断したため。
- 最小fetch間隔の20sは想定数値　根拠はない
- shouldFetchのif分岐内でtry-catchを書いた理由
catchでlastFetchedAtを設定している。外のfinallyでこれを記述するとフェッチ後ではなく採点後になり意味が変わってしまう。結果、言葉の意味を重視してif分岐の中にtry-catchを仕込んだ。
- 取得した復習キューを次のキューに反映させない理由
「...→回答→fetch→出題→...」fetchの結果を待って出題すると、回答から出題までの時間が長くなりテンポが悪い。復習の順序の整合性よりテンポを重視しているので、次に出題されるカードはfetch更新前のものとなる。
例）
```
queue1
card1 → card2 → card3 → ...

↓　card1復習完了

queue1（古い）
card2（使用） → card3 → ... // card3以降破棄

queue2（最新）
card2（破棄） → card3 → ... // card3以降使用
```
---
Closes #106 