### PR TITLE
Feat/review frontend test

### DIFF
--- a/frontend/features/review/hooks/useReviewMutation.test.ts
+++ b/frontend/features/review/hooks/useReviewMutation.test.ts
@@ -1,0 +1,118 @@
+// apiClient レベルでモックする。
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+import { ReviewRating } from '@memo-anki/shared';
+import { apiClient } from '@/lib/api/client';
+import { toast } from 'sonner';
+import { useReviewMutation } from './useReviewMutation';
+
+// apiClient と sonner をモック
+vi.mock('@/lib/api/client', () => ({
+  apiClient: vi.fn(),
+}));
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// 各テストで新しいQueryClientを作る (キャッシュ汚染を避ける)
+const createWrapper = () => {
+  const queryClient = new QueryClient();
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper };
+};
+
+beforeEach(() => {
+  vi.mocked(apiClient).mockReset();
+  vi.mocked(toast.success).mockReset();
+  vi.mocked(toast.error).mockReset();
+});
+
+describe('useReviewMutation', () => {
+  // 正常系: 成功時にtoastが呼ばれない
+  it('成功時はトーストを出さず isSuccess=true になる', async () => {
+    vi.mocked(apiClient).mockResolvedValueOnce({ id: 'card-1' });
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useReviewMutation(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.reviewedCard.mutate([
+      'card-1',
+      { rating: ReviewRating.GOOD, version: 1 },
+    ]);
+
+    await waitFor(() =>
+      expect(result.current.reviewedCard.isSuccess).toBe(true),
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  // 異常系はswitch分岐のテストになるので行わない。
+
+  // ratingがnumberで送信されること
+  it.each([
+    ['AGAIN', ReviewRating.AGAIN, 0],
+    ['HARD', ReviewRating.HARD, 1],
+    ['GOOD', ReviewRating.GOOD, 2],
+    ['EASY', ReviewRating.EASY, 3],
+  ] as const)(
+    '%s を渡すとRatingが %i(number) で送信される',
+    async (_label, ratingEnum, expectedNumber) => {
+      vi.mocked(apiClient).mockResolvedValueOnce({ id: 'card-1' });
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(() => useReviewMutation(), {
+        wrapper: Wrapper,
+      });
+
+      result.current.reviewedCard.mutate([
+        'card-1',
+        { rating: ratingEnum, version: 7 },
+      ]);
+
+      await waitFor(() =>
+        expect(result.current.reviewedCard.isSuccess).toBe(true),
+      );
+
+      // mockでURL/method/bodyをまとめて検証
+      expect(apiClient).toHaveBeenCalledWith('/card/card-1/review', 'POST', {
+        rating: expectedNumber,
+        version: 7,
+      });
+      // ratingがnumberであることを確認
+      const calledBody = vi.mocked(apiClient).mock.calls[0][2] as {
+        rating: unknown;
+      };
+      expect(typeof calledBody.rating).toBe('number');
+    },
+  );
+
+  // 正しいカードに対して採点が送られること
+  it('採点APIのURLは /card/<cardId>/review でリクエストされる', async () => {
+    vi.mocked(apiClient).mockResolvedValueOnce({ id: '123456' });
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useReviewMutation(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.reviewedCard.mutate([
+      '123456',
+      { rating: ReviewRating.GOOD, version: 42 },
+    ]);
+
+    await waitFor(() =>
+      expect(result.current.reviewedCard.isSuccess).toBe(true),
+    );
+    expect(apiClient).toHaveBeenCalledWith(
+      '/card/123456/review',
+      'POST',
+      expect.objectContaining({ version: 42 }),
+    );
+  });
+});

--- a/frontend/features/review/hooks/useReviewQueue.test.ts
+++ b/frontend/features/review/hooks/useReviewQueue.test.ts
@@ -1,0 +1,361 @@
+// 副作用と分岐の結合試験
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  type MockInstance,
+} from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+import { ReviewRating } from '@memo-anki/shared';
+import { apiClient } from '@/lib/api/client';
+import { toast } from 'sonner';
+import { HttpError } from '@/lib/api/httpError';
+import { useReviewCards } from './useReviewQueue';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: vi.fn(),
+}));
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// テストで使う基準時刻（差分で使うので21s以上であれば良い）
+const NOW = 100000;
+
+// CardReviewResponse は OpenAPI 由来の型だが、テストでは id と version しか触らないので最小化
+type Card = {
+  id: string;
+  deckId: string;
+  name: string;
+  type: number;
+  content?: string;
+  question?: string;
+  answer?: string;
+  queue: number;
+  nextReviewAt: string;
+  version: number;
+};
+
+const mkCard = (id: string, version = 1): Card => ({
+  id,
+  deckId: 'd1',
+  name: id,
+  type: 0,
+  content: id,
+  queue: 0,
+  nextReviewAt: '2026-01-01T00:00:00Z',
+  version,
+});
+
+// 各テストで新しい QueryClient を使う (キャッシュ汚染を避ける)
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    // 異常系テストを高速にするためretryを拒否
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper };
+};
+
+// apiClient の呼び出しから GET / POST だけ抽出するヘルパ
+const filterCalls = (method: 'GET' | 'POST') =>
+  vi.mocked(apiClient).mock.calls.filter((c) => c[1] === method);
+
+let nowSpy: MockInstance<() => number>;
+
+// mock
+beforeEach(() => {
+  vi.mocked(apiClient).mockReset();
+  vi.mocked(toast.error).mockReset();
+  vi.mocked(toast.success).mockReset();
+  // Date.now() を固定。TanStack Query の dataUpdatedAt も NOW になる
+  nowSpy = vi.spyOn(Date, 'now').mockReturnValue(NOW);
+});
+
+afterEach(() => {
+  nowSpy.mockRestore();
+});
+
+describe('useReviewCards', () => {
+  // ============================================================
+  // ケース1: 初回ロード
+  // ============================================================
+  it('初回ロード後、キューの先頭が current になり finished=false', async () => {
+    vi.mocked(apiClient).mockResolvedValueOnce([
+      mkCard('c1'),
+      mkCard('c2'),
+      mkCard('c3'),
+    ]);
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useReviewCards('d1'), {
+      wrapper: Wrapper,
+    });
+
+    // 初期状態: ロード中
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.current).toBeNull();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.current?.id).toBe('c1');
+    expect(result.current.finished).toBe(false);
+    expect(result.current.isError).toBe(false);
+
+    // 初回 GET が getReviewQueue の契約通り `/card/review?deckId=<id>` で呼ばれていること
+    // フック経由でも API パスが崩れていないことを担保する
+    const getCalls = filterCalls('GET');
+    expect(getCalls).toHaveLength(1);
+    expect(getCalls[0][0]).toBe('/card/review?deckId=d1');
+  });
+
+  // ============================================================
+  // ケース2: rating() で採点 / 残量豊富 + 経過短い → 再fetch しない
+  // ============================================================
+  it('採点後、shouldFetch=false なら再fetch せず次のカードに進む', async () => {
+    vi.mocked(apiClient)
+      // 初回 GET: 5件
+      .mockResolvedValueOnce([
+        mkCard('c1'),
+        mkCard('c2'),
+        mkCard('c3'),
+        mkCard('c4'),
+        mkCard('c5'),
+      ])
+      // POST 成功
+      .mockResolvedValueOnce({ id: 'c1' });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useReviewCards('d1'), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current.current?.id).toBe('c1'));
+
+    await act(async () => {
+      await result.current.rating(ReviewRating.GOOD);
+    });
+
+    // 次のカードに進んでいる
+    expect(result.current.current?.id).toBe('c2');
+    // POST は1回呼ばれた
+    expect(filterCalls('POST')).toHaveLength(1);
+    // GET は初回の1回だけ (再fetch は発火していない)
+    expect(filterCalls('GET')).toHaveLength(1);
+  });
+
+  // ============================================================
+  // ケース3: 残量 ≤ 3 のとき強制 re-fetch & mergeQueue 適用
+  // ============================================================
+  it('残量3件のとき強制 fetch が走り、mergeQueue で先頭が保護される', async () => {
+    vi.mocked(apiClient)
+      // 初回 GET: 4件 (採点後の残量は3件 → 強制fetch)
+      .mockResolvedValueOnce([
+        mkCard('c1'),
+        mkCard('c2'),
+        mkCard('c3'),
+        mkCard('c4'),
+      ])
+      // POST 成功
+      .mockResolvedValueOnce({ id: 'c1' })
+      // 再 fetch GET: c2 が含まれていても重複除外される
+      .mockResolvedValueOnce([
+        mkCard('c2'),
+        mkCard('c5'),
+        mkCard('c6'),
+        mkCard('c7'),
+        mkCard('c8'),
+      ]);
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useReviewCards('d1'), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current.current?.id).toBe('c1'));
+
+    await act(async () => {
+      await result.current.rating(ReviewRating.GOOD);
+    });
+
+    // 表示中(=先頭)は c2 のまま、後続は新キューで置換され重複除去
+    expect(result.current.current?.id).toBe('c2');
+    // 再 fetch が発火していること (GET 2回)
+    expect(filterCalls('GET')).toHaveLength(2);
+  });
+
+  // ============================================================
+  // ケース4: 採点ロック (連打されても POST は1回だけ)
+  // ※ 旧ケース4 (20s経過で再fetch) は shouldFetch.test.ts でカバー済みのため削除
+  // ============================================================
+  it('rating() の連打中は2回目の呼び出しが採点ロックで弾かれる', async () => {
+    // POST を保留状態にしておく（resolve するまで先に進ませない）
+    let resolvePost: (value: unknown) => void = () => {};
+    const pendingPost = new Promise<unknown>((res) => {
+      resolvePost = res;
+    });
+
+    vi.mocked(apiClient).mockImplementation((_url: string, method: string) => {
+      if (method === 'GET') {
+        return Promise.resolve([
+          mkCard('c1'),
+          mkCard('c2'),
+          mkCard('c3'),
+          mkCard('c4'),
+          mkCard('c5'),
+        ]);
+      }
+      if (method === 'POST') {
+        return pendingPost;
+      }
+      return Promise.reject(new Error('unexpected'));
+    });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useReviewCards('d1'), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current.current?.id).toBe('c1'));
+
+    // 1回目の rating() は POST 待ちで suspend する
+    // 2回目の rating() は isRating.current=true で早期 return する想定
+    let p1: Promise<void> | undefined;
+    let p2: Promise<void> | undefined;
+    await act(async () => {
+      p1 = result.current.rating(ReviewRating.GOOD);
+      p2 = result.current.rating(ReviewRating.GOOD);
+      // 1回目の同期パートが流れるよう microtask を1度はかせる
+      await Promise.resolve();
+    });
+
+    // この時点で POST は1回しか発火していない
+    expect(filterCalls('POST')).toHaveLength(1);
+
+    // POST を resolve して両 Promise を回収
+    await act(async () => {
+      resolvePost({ id: 'c1' });
+      if (p1) await p1;
+      if (p2) await p2;
+    });
+
+    // resolve 後も POST 数は1回のまま
+    // (2回目の rating が「ロックで遅延されたあとに発火する」ような実装ミスの検出)
+    expect(filterCalls('POST')).toHaveLength(1);
+  });
+
+  // ============================================================
+  // ケース5: 採点 API がエラー → toast表示、ロック解除
+  // ※ id細部 (c3) や再fetch回数の確認は内部実装依存のため省略。
+  //   主目的は「toast が出る」「ロックが解除されて2回目も POST できる」の2点。
+  // ============================================================
+  it('採点APIがエラーの場合 toast を出してロックは解除される', async () => {
+    vi.mocked(apiClient)
+      // 初回 GET: 8件 (2回採点しても残量5件で shouldFetch=false を維持できる)
+      .mockResolvedValueOnce([
+        mkCard('c1'),
+        mkCard('c2'),
+        mkCard('c3'),
+        mkCard('c4'),
+        mkCard('c5'),
+        mkCard('c6'),
+        mkCard('c7'),
+        mkCard('c8'),
+      ])
+      // POST が 500 で失敗
+      .mockRejectedValueOnce(new HttpError(500, 'server error'))
+      // 次の rating() の POST 用 (ロック解除を確認)
+      .mockResolvedValueOnce({ id: 'c2' });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useReviewCards('d1'), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current.current?.id).toBe('c1'));
+
+    await act(async () => {
+      await result.current.rating(ReviewRating.GOOD);
+    });
+
+    // useReviewMutation の onError で toast.error が呼ばれる
+    expect(toast.error).toHaveBeenCalledWith('サーバーエラーが発生しました');
+    // 失敗しても UI は次のカードに進んでいる (楽観的更新)
+    expect(result.current.current?.id).toBe('c2');
+
+    // ロックが解除されていれば、続けて rating() できる (POST がもう1回発火する)
+    await act(async () => {
+      await result.current.rating(ReviewRating.GOOD);
+    });
+    expect(filterCalls('POST')).toHaveLength(2);
+  });
+
+  // ============================================================
+  // ケース6: 再 fetch がエラー → サイレント継続
+  // ============================================================
+  it('再 fetch が失敗しても toast は出ず、残存キューで継続できる', async () => {
+    vi.mocked(apiClient)
+      // 初回 GET: 3件 (採点後 2件 ≤ 3 で強制 fetch)
+      .mockResolvedValueOnce([mkCard('c1'), mkCard('c2'), mkCard('c3')])
+      // POST 成功
+      .mockResolvedValueOnce({ id: 'c1' })
+      // 再 fetch がネットワークエラー
+      .mockRejectedValueOnce(new Error('NetworkError'));
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useReviewCards('d1'), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current.current?.id).toBe('c1'));
+
+    await act(async () => {
+      await result.current.rating(ReviewRating.GOOD);
+    });
+
+    // toast は出ない (fetch エラーはサイレント仕様)
+    expect(toast.error).not.toHaveBeenCalled();
+    // 採点前に setLocalQueue で前進済みのため、c2 が表示されている
+    expect(result.current.current?.id).toBe('c2');
+    // 再 fetch は試みた (GET は2回呼ばれた) ことだけ確認
+    expect(filterCalls('GET')).toHaveLength(2);
+  });
+
+  // ============================================================
+  // ケース7: 全カードを採点しきると finished=true、その後のrating()はPOSTしない
+  // ============================================================
+  it('全カードを採点しきると finished=true になり、rating() は no-op', async () => {
+    vi.mocked(apiClient)
+      // 初回 GET: 1件だけ
+      .mockResolvedValueOnce([mkCard('c1')])
+      // POST 成功
+      .mockResolvedValueOnce({ id: 'c1' })
+      // 再 fetch (length=0 ≤ 3 で強制) も空
+      .mockResolvedValueOnce([]);
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useReviewCards('d1'), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current.current?.id).toBe('c1'));
+
+    await act(async () => {
+      await result.current.rating(ReviewRating.GOOD);
+    });
+
+    expect(result.current.current).toBeNull();
+    expect(result.current.finished).toBe(true);
+    // POST はここまでで1回だけ
+    expect(filterCalls('POST')).toHaveLength(1);
+
+    // queue=0 状態で rating() を再度呼んでもPOST は増えない
+    await act(async () => {
+      await result.current.rating(ReviewRating.GOOD);
+    });
+    expect(filterCalls('POST')).toHaveLength(1);
+  });
+});

--- a/frontend/features/review/hooks/useReviewQueue.ts
+++ b/frontend/features/review/hooks/useReviewQueue.ts
@@ -77,9 +77,9 @@ export function useReviewCards(deckId: string): ReviewQueueState {
       const head = queue[0];
 
       // 先頭のCard以外取り出してstateに保存
-      const nextQueue = queue.slice(1);
+      const remainingQueue = queue.slice(1);
       // 次のqueueを待たず次のカードへ進める
-      setLocalQueue(nextQueue);
+      setLocalQueue(remainingQueue);
 
       try {
         // 採点API呼び出し
@@ -89,11 +89,13 @@ export function useReviewCards(deckId: string): ReviewQueueState {
         ]);
 
         // fetch条件
-        if (shouldFetch(nextQueue, lastFetchAt.current)) {
+        if (shouldFetch(remainingQueue, lastFetchAt.current)) {
           try {
             const newCards = await fetchReviewQueue(deckId);
             //mergeQueueで合成したQueueを保存（関数形式によりawaitによる参照ずれを防ぐ）
-            setLocalQueue((prev) => mergeQueue(prev ?? nextQueue, newCards));
+            setLocalQueue((prev) =>
+              mergeQueue(prev ?? remainingQueue, newCards),
+            );
           } finally {
             lastFetchAt.current = Date.now();
           }

--- a/frontend/features/review/lib/mergeQueue.test.ts
+++ b/frontend/features/review/lib/mergeQueue.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { mergeQueue } from './mergeQueue';
+
+// ヘルパ
+type CardLike = Parameters<typeof mergeQueue>[0][number];
+const makeCard = (id: string): CardLike => ({ id }) as unknown as CardLike;
+
+describe('mergeQueue', () => {
+  // 分岐1: currentQueue.length === 0
+  it('currentQueue が空のときは nextQueue をそのまま返す', () => {
+    const next = [makeCard('a'), makeCard('b')];
+    const result = mergeQueue([], next);
+    expect(result).toEqual(next);
+  });
+
+  // 分岐2: 先頭1件を守りつつ、nextQueue から重複を除外する
+  it('nextQueue に表示中カードと同じ id があるとき、それは除外され先頭が保護される', () => {
+    // currentのAかという確認は必要ない。useReviewQueueにおいてmergeQueue()前にsetされている）
+    const current = [makeCard('a'), makeCard('b'), makeCard('c')];
+    const next = [makeCard('a'), makeCard('x'), makeCard('y')];
+    const result = mergeQueue(current, next);
+    //
+    expect(result.map((c) => c.id)).toEqual(['a', 'x', 'y']);
+  });
+
+  // 分岐3: 重複が無いケース → そのまま [head, ...next] になる
+  it('nextQueue に重複が無いとき、[先頭, ...nextQueue] が返る', () => {
+    // 通常おこりえないはずの分岐
+    const current = [makeCard('a'), makeCard('b')];
+    const next = [makeCard('x'), makeCard('y')];
+    const result = mergeQueue(current, next);
+    expect(result.map((c) => c.id)).toEqual(['a', 'x', 'y']);
+  });
+
+  // 分岐3: nextQueue が空でも先頭は守られる
+  it('nextQueue が空でも先頭1件は残る', () => {
+    // jsの仕様確認と同義だが分岐として価値はある。
+    const current = [makeCard('a'), makeCard('b')];
+    const result = mergeQueue(current, []);
+    expect(result.map((c) => c.id)).toEqual(['a']);
+  });
+});

--- a/frontend/features/review/lib/shouldFetch.test.ts
+++ b/frontend/features/review/lib/shouldFetch.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { shouldFetch } from './shouldFetch';
+
+// テストで使う時刻の基準（20001以上なら適当な値で良い）
+const NOW = 100000;
+
+// 任意件数のダミーキューを作るヘルパ
+// shouldFetchはlengthしか見ないのでidだけあれば十分
+type CardLike = Parameters<typeof shouldFetch>[0][number];
+// 長さだけで中身のないダミーカード配列作成
+const makeQueue = (n: number): CardLike[] =>
+  Array.from(
+    { length: n }, // 長さnで中身のない配列
+    (_, i) => ({ id: String(i) }) as unknown as CardLike, // mapping
+  );
+
+describe('shouldFetch', () => {
+  beforeEach(() => {
+    // システム時刻を固定し、Date.now() を NOW に揃える
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // 残り三件以下の時強制fetch
+  it.each([0, 1, 2, 3])(
+    '残り %i 件のとき経過時間が短くても true（強制 fetch）',
+    (n) => {
+      const queue = makeQueue(n);
+      // lastFetchAt = NOW なので最小fetch間隔は満たしていない
+      expect(shouldFetch(queue, NOW)).toBe(true);
+    },
+  );
+
+  // 残り４件の境界値かつ閾値の一歩手前でfetchしない
+  it('残り 4 件で経過 19999ms のときは fetch しない', () => {
+    const queue = makeQueue(4);
+    // 19999ms 前にfetchしたという想定
+    const lastFetchAt = NOW - 19_999;
+    expect(shouldFetch(queue, lastFetchAt)).toBe(false);
+  });
+
+  // 閾値20000msちょうどでfetch
+  it('残り 4 件で経過 20000ms ちょうどのときは fetch する', () => {
+    const queue = makeQueue(4);
+    const lastFetchAt = NOW - 20_000;
+    expect(shouldFetch(queue, lastFetchAt)).toBe(true);
+  });
+
+  // 残り10件で20s未満の時はfetchしない
+  it('残り 10 件で経過 5 秒のときは fetch しない', () => {
+    const queue = makeQueue(10);
+    const lastFetchAt = NOW - 5_000;
+    expect(shouldFetch(queue, lastFetchAt)).toBe(false);
+  });
+
+  // 初回などでlastFetchAt = 0 のときはfetch
+  it('lastFetchAt = 0 のときはfetchする', () => {
+    const queue = makeQueue(10);
+    expect(shouldFetch(queue, 0)).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要
復習画面の試験を行った。
CRUDのフロントエンド試験と同様の方針。
全てのテストは行わず、副作用やAPI接続など、ユーザが利用を続けられなくなる重要な箇所に絞って試験を行った。

## 詳細
shouldFetch, mergeQueue, useReviewMutationは純粋なロジックなため単体試験を実施。
useReviewQueueはそれぞれの関数を組み合わせた司令塔的なロジックのため結合試験として実施。
詳しくは各ソースのコメントに記載。

---

Closes #113 