### PR TITLE
feat: NotionIntegrationスキーマを作成

### DIFF
--- a/backend/prisma/migrations/20260510075335_add_notion_integration/migration.sql
+++ b/backend/prisma/migrations/20260510075335_add_notion_integration/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "notion_integrations" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "accessTokenEnc" TEXT NOT NULL,
+    "refreshTokenEnc" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "workspaceName" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "notion_integrations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "notion_integrations_userId_key" ON "notion_integrations"("userId");
+
+-- AddForeignKey
+ALTER TABLE "notion_integrations" ADD CONSTRAINT "notion_integrations_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -16,15 +16,16 @@ datasource db {
 
 // Userテーブル
 model User {
-  id                    String    @id @default(uuid())
-  username              String    @unique
-  email                 String?   @unique
+  id                    String             @id @default(uuid())
+  username              String             @unique
+  email                 String?            @unique
   passwordHash          String
   refreshTokenHash      String?
   refreshTokenExpiresAt DateTime? // refreshToken有効期限
-  createdAt             DateTime  @default(now())
-  updatedAt             DateTime  @updatedAt
+  createdAt             DateTime           @default(now())
+  updatedAt             DateTime           @updatedAt
   decks                 Deck[]
+  notionIntegration     NotionIntegration? // notion連携テーブル
 
   @@map("users")
 }
@@ -79,4 +80,19 @@ model Card {
   // デッキごとのカード取得を高速化
   @@index([deckId])
   @@map("card")
+}
+
+model NotionIntegration {
+  id              String   @id @default(uuid())
+  userId          String   @unique
+  accessTokenEnc  String // 暗号化済
+  refreshTokenEnc String // 暗号化済
+  workspaceId     String
+  workspaceName   String
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  // userが削除されたら自動でnotionIntegrationも削除
+  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("notion_integrations")
 }


### PR DESCRIPTION
スキーマ作成

botidは含めないことにした。このカラムはデバック用がメインで今のところほかのカラムで対応できると考え、切り捨てた。

暗号化については、CryptoJSを検討したがメンテナンスが定期的にないこと、node.jsの標準ライブラリCryptogがあることからそちらを採用する。

---
Closes #117 
