### PR TITLE
Feat/cipheriv

### DIFF
--- a/backend/src/common/encryption/cipher.service.spec.ts
+++ b/backend/src/common/encryption/cipher.service.spec.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { randomBytes } from 'crypto';
+import { CipherService } from './cipher.service';
+import { TokenCipherError } from '../exceptions/cipher.exceptions';
+
+/**
+ * 暗号化ロジックの単体試験
+ *
+ * 主に以下の観点で試験する
+ * 正常系
+ * - encryptした結果をdecryptすると元の平文に戻る
+ * - 同じ平文を2回encryptしても結果が異なる（ランダムの検証）
+ * - 返り値がbase64であること
+ * 異常系
+ * - encryptが失敗するとTokenCipherErrorを投げること
+ * - decryptが失敗するとTokenCipherErrorを投げること
+ * - 暗号文を改ざんするとTokenCipherErrorを投げること（改ざん検知）
+ */
+
+describe('CipherService', () => {
+  let service: CipherService;
+
+  // テスト全体で共通の鍵を使うため、ここで一度だけ初期化する
+  beforeAll(() => {
+    // AES-256-GCM 用の 32バイト鍵を hex 文字列で用意する
+    process.env.NOTION_TOKEN_ENC_KEY = randomBytes(32).toString('hex');
+
+    // Nest の DI を使わず、直接インスタンス化
+    service = new CipherService();
+    // this.keyにenvを読み込ませる
+    service.onModuleInit();
+  });
+
+  //
+  // 正常系
+  //
+  describe('正常系', () => {
+    it('encrypt → decrypt で元の平文に戻ること', () => {
+      const plaintext = 'secret-notion-token-abcdef';
+      const encrypted = service.encrypt(plaintext);
+
+      // 復号した結果が元の文字列と完全一致することを確認
+      expect(service.decrypt(encrypted)).toBe(plaintext);
+    });
+
+    it('同じ平文を2回encryptしても結果が異なること（ランダム性）', () => {
+      // GCMは毎回ランダムなIVを使うため、同じ平文でも暗号文は別になる
+      const plaintext = 'same-plaintext';
+      const enc1 = service.encrypt(plaintext);
+      const enc2 = service.encrypt(plaintext);
+
+      // 暗号文同士は一致してはいけない
+      expect(enc1).not.toBe(enc2);
+      // 復号すれば両方とも同じ平文になる
+      expect(service.decrypt(enc1)).toBe(plaintext);
+      expect(service.decrypt(enc2)).toBe(plaintext);
+    });
+
+    it('encryptの返り値がbase64文字列であること', () => {
+      const encrypted = service.encrypt('hello');
+
+      // base64で使われる文字（A-Z, a-z, 0-9, +, /, =）のみで構成される
+      expect(encrypted).toMatch(/^[A-Za-z0-9+/]+=*$/);
+
+      // base64としてデコードでき、iv(12) + authTag(16) = 最低28バイト以上
+      const buf = Buffer.from(encrypted, 'base64');
+      expect(buf.length).toBeGreaterThanOrEqual(12 + 16);
+    });
+  });
+
+  //
+  // 異常系
+  //
+  describe('異常系', () => {
+    it('encryptが失敗するとTokenCipherErrorを投げること', () => {
+      // 鍵長が不正(31バイト)だと createCipheriv が内部で例外を投げる。
+      const broken = new CipherService();
+      // onModuleInit を呼ばず、不正な長さの鍵を直接差し込む
+      (broken as unknown as { key: Buffer }).key = Buffer.alloc(31);
+
+      expect(() => broken.encrypt('x')).toThrow(TokenCipherError);
+    });
+
+    it('decryptが失敗するとTokenCipherErrorを投げること', () => {
+      // 成立しない短い暗号文。 setAuthTagやdecipher.final() の段階で例外になる
+      expect(() => service.decrypt('AAAA')).toThrow(TokenCipherError);
+    });
+
+    it('暗号文を改ざんするとTokenCipherErrorを投げること（改ざん検知）', () => {
+      const plaintext = 'tamper-me';
+      const encrypted = service.encrypt(plaintext);
+
+      // バイト列に戻す
+      const buf = Buffer.from(encrypted, 'base64');
+      // レイアウト: [iv(12) | authTag(16) | ciphertext(...)]
+      // → 28バイト目以降が暗号文。先頭バイトを1bit反転して改ざんする
+      buf[28] ^= 0x01;
+
+      // 改ざんしたbase64を作って復号 → 例外が出ることを確認
+      const tampered = buf.toString('base64');
+      expect(() => service.decrypt(tampered)).toThrow(TokenCipherError);
+    });
+
+    it('authTag部分を改ざんしてもTokenCipherErrorを投げること', () => {
+      // 暗号文本体だけでなく、authTag自体が書き換わっても検知できる
+      const plaintext = 'tamper-tag';
+      const encrypted = service.encrypt(plaintext);
+
+      const buf = Buffer.from(encrypted, 'base64');
+      // レイアウト: [iv(12) | authTag(16) | ciphertext(...)]
+      // 12〜27バイト目がauthTag。先頭(12バイト目)を反転した改ざん
+      buf[12] ^= 0x01;
+
+      const tampered = buf.toString('base64');
+      expect(() => service.decrypt(tampered)).toThrow(TokenCipherError);
+    });
+  });
+});

--- a/backend/src/common/encryption/cipher.service.ts
+++ b/backend/src/common/encryption/cipher.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+import { TokenCipherError } from '../exceptions/cipher.exceptions';
+
+/**
+ * AES-256-GCMによるトークン暗号化/復号サービス
+ */
+@Injectable()
+export class CipherService implements OnModuleInit {
+  private readonly logger = new Logger(CipherService.name);
+
+  // 32バイトの暗号鍵（onModuleInit時に設定される）
+  private key!: Buffer;
+
+  // GCMの推奨IV長（12バイト）
+  private static readonly IV_LENGTH = 12;
+  // GCMの認証タグ長（16バイト）
+  private static readonly AUTH_TAG_LENGTH = 16;
+
+  // CIのOpenAPIスキーマ生成時用の特別処理
+  onModuleInit() {
+    // OpenAPI生成スクリプトはAppModule全体を初期化するため、
+    // 鍵が無くても起動できるようにスキップする（PrismaServiceと同様の方針）
+    if (process.env.GENERATE_OPENAPI === 'true') {
+      this.logger.warn('CIのため暗号鍵チェックをスキップします');
+      return;
+    }
+    // CIは読み込まれないためgithubのsecretに記載したうえでCIにenvを追加した。
+    this.key = Buffer.from(process.env.NOTION_TOKEN_ENC_KEY!, 'hex');
+  }
+
+  /**
+   * 平文を暗号化してbase64文字列で返す
+   * @param plaintext 平文
+   * @returns base64
+   */
+  encrypt(plaintext: string): string {
+    try {
+      // 暗号化のたびにランダムなIVを生成（毎回新規）
+      const iv = randomBytes(CipherService.IV_LENGTH);
+      const cipher = createCipheriv('aes-256-gcm', this.key, iv);
+
+      // 暗号化
+      const ciphertext = Buffer.concat([
+        cipher.update(plaintext, 'utf8'),
+        cipher.final(),
+      ]);
+
+      // 認証タグ（改ざん検出用）を取得
+      const authTag = cipher.getAuthTag();
+
+      // 結合してbase64化
+      return Buffer.concat([iv, authTag, ciphertext]).toString('base64');
+    } catch (e) {
+      throw new TokenCipherError('暗号化に失敗しました', e);
+    }
+  }
+
+  /**
+   * 暗号化済みbase64文字列を復号して平文を返す
+   * @param encoded
+   * @returns 平文
+   */
+  decrypt(encoded: string): string {
+    try {
+      const buf = Buffer.from(encoded, 'base64');
+
+      // 結合バイト列を分解
+      const iv = buf.subarray(0, CipherService.IV_LENGTH);
+      const authTag = buf.subarray(
+        CipherService.IV_LENGTH,
+        CipherService.IV_LENGTH + CipherService.AUTH_TAG_LENGTH,
+      );
+      const ciphertext = buf.subarray(
+        CipherService.IV_LENGTH + CipherService.AUTH_TAG_LENGTH,
+      );
+
+      const decipher = createDecipheriv('aes-256-gcm', this.key, iv);
+      decipher.setAuthTag(authTag);
+
+      // 復号（authTag不一致時はここで例外）
+      const plaintext = Buffer.concat([
+        decipher.update(ciphertext),
+        decipher.final(),
+      ]);
+      return plaintext.toString('utf8');
+    } catch (e) {
+      throw new TokenCipherError('復号に失敗しました', e);
+    }
+  }
+}

--- a/backend/src/common/encryption/encryption.module.ts
+++ b/backend/src/common/encryption/encryption.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { CipherService } from './cipher.service';
+
+/**
+ * 暗号化サービスを提供するモジュール
+ * keyを.envにから取得するためDIする必要がある。
+ */
+@Module({
+  providers: [CipherService],
+  exports: [CipherService],
+})
+export class EncryptionModule {}

--- a/backend/src/common/exceptions/cipher.exceptions.ts
+++ b/backend/src/common/exceptions/cipher.exceptions.ts
@@ -1,0 +1,8 @@
+/**
+ * 暗号化エラークラス
+ */
+export class TokenCipherError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message, { cause });
+  }
+}


### PR DESCRIPTION
## 概要
共通かぎ暗号方式であるAES-256-GCMの実装を行った。デファクトスタンダードな暗号方式である。
以下の仕組みに沿って実装した。

## AES-256-GCMの仕組み 
- 暗号化に使うものとして平文, Key, ivがある。 ivとは初期化ベクトルといい、ランダムな値である。keyに付与することで毎回の暗号化において、 それぞれ異なる暗号化処理にすることができる。 
- 改ざん検知に使うものとして暗号文, 認証タグがある。 認証タグは暗号文とkeyなどと組み合わせた値をhash化(SHAではない)する。 その値を暗号文に付与することで改ざんの検知をすることができる。

## cryptoを使った理由
CryptoJSなど外部ライブラリを使うと実装が簡単になるため検討したが更新が止まっているなど信頼性がない。そのため多少コード量が多くなるが信頼性の高いnode.js標準のcryptoを採用した。