### PR TITLE
Feat/notion oauth flow

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { UserModule } from './user/user.module';
 import { AuthModule } from './auth/auth.module';
 import { DeckModule } from './deck/deck.module';
 import { CardModule } from './card/card.module';
+import { NotionModule } from './integrations/notion/notion.module';
 import { ConfigModule } from '@nestjs/config';
 
 @Module({
@@ -17,6 +18,7 @@ import { ConfigModule } from '@nestjs/config';
     AuthModule,
     DeckModule,
     CardModule,
+    NotionModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/common/functions/get-env.ts
+++ b/backend/src/common/functions/get-env.ts
@@ -1,0 +1,19 @@
+import { InternalServerErrorException, Logger } from '@nestjs/common';
+
+// notion連携完了後にenv使用箇所への例外処理の追加と起動前env確認を行う。
+// issue#126に詳細記述
+/**
+ * 環境変数の取得（未設定なら500）
+ * 起動前にenvチェックを行っているためenv書き忘れの確認になる
+ */
+export function getEnv(name: string): string {
+  const logger = new Logger('getEnv');
+  const value = process.env[name];
+  if (!value) {
+    logger.error(`環境変数 ${name} が設定されていません。`);
+    throw new InternalServerErrorException(
+      `環境変数 ${name} が設定されていません。`,
+    );
+  }
+  return value;
+}

--- a/backend/src/integrations/notion/dto/notion-status.response.ts
+++ b/backend/src/integrations/notion/dto/notion-status.response.ts
@@ -1,0 +1,20 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * フロント側で「Notion連携」ボタンの表示出し分けに使用する
+ */
+export class NotionStatusResponse {
+  @ApiProperty({ example: true, description: 'Notion連携済みかどうか' })
+  connected: boolean;
+
+  @ApiPropertyOptional({
+    example: 'My Workspace',
+    description: '連携先のNotionワークスペース名（connected=trueのみ）',
+  })
+  workspaceName?: string;
+
+  constructor(connected: boolean, workspaceName?: string) {
+    this.connected = connected;
+    this.workspaceName = workspaceName;
+  }
+}

--- a/backend/src/integrations/notion/notion-integration.repository.ts
+++ b/backend/src/integrations/notion/notion-integration.repository.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@nestjs/common';
+import { NotionIntegration } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CipherService } from '../../common/encryption/cipher.service';
+
+/**
+ * upsert/insert時の入力契約
+ * AT/RTは平文で受け取り、Repository層で暗号化してDBへ書き込む
+ */
+export type UpsertNotionIntegrationInput = {
+  userId: string;
+  accessToken: string; // 平文（DB書き込み時に暗号化される）
+  refreshToken: string; // 平文（DB書き込み時に暗号化される）
+  workspaceId: string;
+  workspaceName: string;
+};
+
+/**
+ * NotionIntegrationのDB操作Repository
+ *
+ * - 暗号化/復号はこの層で透過処理する
+ * - 上位レイヤ（Service/Controller）は暗号化を意識しない
+ */
+@Injectable()
+export class NotionIntegrationRepository {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly cipher: CipherService,
+  ) {}
+
+  /**
+   * userIdでnotionIntegrationの存在確認。
+   * status確認や存在チェックに使う。
+   */
+  async findByUserId(userId: string): Promise<NotionIntegration | null> {
+    return this.prisma.notionIntegration.findUnique({
+      where: { userId },
+    });
+  }
+
+  /**
+   * 同一userIdのレコードをあれば上書き、なければ新規作成する
+   *
+   * Notion設計上、１ユーザは常に最新の１連携情報のみを持つ。
+   */
+  async upsert(
+    input: UpsertNotionIntegrationInput,
+  ): Promise<NotionIntegration> {
+    // トークンを暗号化
+    const accessTokenEnc = this.cipher.encrypt(input.accessToken);
+    const refreshTokenEnc = this.cipher.encrypt(input.refreshToken);
+
+    // create用とupdate用で共通する書き込みカラム
+    const data = {
+      accessTokenEnc,
+      refreshTokenEnc,
+      workspaceId: input.workspaceId,
+      workspaceName: input.workspaceName,
+    };
+
+    return this.prisma.notionIntegration.upsert({
+      where: { userId: input.userId },
+      create: {
+        userId: input.userId,
+        ...data,
+      },
+      update: data,
+    });
+  }
+
+  /**
+   * userIdに紐づくNotionIntegrationを削除する
+   */
+  async delete(userId: string): Promise<void> {
+    await this.prisma.notionIntegration.deleteMany({
+      where: { userId },
+    });
+  }
+}

--- a/backend/src/integrations/notion/notion-oauth.controller.ts
+++ b/backend/src/integrations/notion/notion-oauth.controller.ts
@@ -1,0 +1,159 @@
+import {
+  BadRequestException,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Query,
+  Req,
+  Res,
+  UseFilters,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiResponse } from '@nestjs/swagger';
+import express from 'express';
+import { JwtAuthGuard } from '../../auth/jwt.guard';
+import { GetUserId } from '../../common/decorators/get-userid.decorator';
+import { NotionStatusResponse } from './dto/notion-status.response';
+import {
+  NotionOAuthService,
+  NotionTokenResponse,
+} from './notion-oauth.service';
+import { NotionOAuthExceptionFilter } from './notion-oauth.exception.filter';
+import {
+  COOKIE_MAX_AGE,
+  COOKIE_OAUTH_DECK_ID,
+  COOKIE_OAUTH_STATE,
+  COOKIE_OAUTH_USER_ID,
+  clearOAuthCookies,
+} from '../../integrations/notion/notion-oauth.cookies';
+
+/** フロントエンドURL */
+const frontendUrl = process.env.FRONTEND_URL ?? '';
+
+@Controller('/integrations/notion')
+export class NotionOAuthController {
+  constructor(private readonly notionOAuthService: NotionOAuthService) {}
+
+  /**
+   * Notionに対して認可申請
+   */
+  @UseGuards(JwtAuthGuard)
+  @Get('auth')
+  startAuth(
+    @GetUserId() userId: string,
+    @Query('deckId') deckId: string | undefined,
+    @Res() res: express.Response,
+  ) {
+    // deckIdは認可後のフロント遷移先に使うため必須
+    if (!deckId) throw new BadRequestException('deckId は必須です。');
+
+    // CSRF対策のランダムstateを生成
+    const state = this.notionOAuthService.generateState();
+
+    const cookieOptions: express.CookieOptions = {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production', // Secure: 本番のみ
+      sameSite: 'lax',
+      path: '/',
+      maxAge: COOKIE_MAX_AGE, // 5分
+    };
+    res.cookie(COOKIE_OAUTH_STATE, state, cookieOptions);
+    res.cookie(COOKIE_OAUTH_DECK_ID, deckId, cookieOptions);
+    res.cookie(COOKIE_OAUTH_USER_ID, userId, cookieOptions);
+
+    // Notion認可画面へ302リダイレクト
+    const authorizationUrl =
+      this.notionOAuthService.buildAuthorizationUrl(state);
+    return res.redirect(authorizationUrl);
+  }
+
+  /**
+   * Notion側からのリクエストを受け取るエンドポイント
+   *
+   * - ATを返さないのでcookieに認証情報を入れる。
+   * RTをcookieに含めればいいが、JWT認証に依存するため使わない。
+   * - 3つのQueryはNotion側のOAuthの仕様に沿って設定。
+   * - 発生した例外は独自filterで吸収しフラグを立ててリダイレクトする。
+   */
+  @UseFilters(NotionOAuthExceptionFilter)
+  @Get('callback')
+  async callback(
+    @Query('code') code: string | undefined,
+    @Query('state') queryState: string | undefined,
+    @Query('error') error: string | undefined,
+    @Req() req: express.Request,
+    @Res() res: express.Response,
+  ) {
+    // 型を絞ってCookieを参照
+    const cookies = req.cookies as Record<string, string | undefined>;
+    const cookieState = cookies[COOKIE_OAUTH_STATE];
+    const deckId = cookies[COOKIE_OAUTH_DECK_ID];
+    const userId = cookies[COOKIE_OAUTH_USER_ID];
+
+    /** バリデーション */
+    // state検証（CSRF対策）クエリが偽造されている可能性有
+    if (!queryState || !cookieState || queryState !== cookieState) {
+      throw new BadRequestException('state が不正、または期限切れです。');
+    } else {
+      // ユーザがNotion側で認可拒否した場合
+      if (error) {
+        clearOAuthCookies(res);
+        // フロントへredirectしてcancelを伝える
+        return res.redirect(
+          `${frontendUrl}/decks/${deckId}?integration=notion_cancelled`,
+        );
+      }
+      // 認可codeが無ければ中止
+      if (!code) {
+        throw new BadRequestException('code が含まれていません。');
+      }
+      // userId Cookie, deckId Cookieが無ければ中止
+      if (!userId) {
+        throw new BadRequestException('userId Cookieが見つかりません。');
+      }
+      if (!deckId) {
+        throw new BadRequestException('deckId Cookieが見つかりません。');
+      }
+    }
+
+    // Notion APIへcodeをPOSTしてAT/RTを取得
+    const tokens: NotionTokenResponse =
+      await this.notionOAuthService.exchangeCodeForTokens(code);
+
+    // 暗号化してupsert保存
+    await this.notionOAuthService.saveNotionResponse(userId, tokens);
+
+    // OAuth用Cookieを破棄する（再利用防止）
+    // 失敗時はfilter内でCookie破棄する
+    clearOAuthCookies(res);
+
+    // フロントのimport画面へredirect
+    return res.redirect(
+      // urlは適当に決めた、フロント作成時に変更
+      `${frontendUrl}/decks/${deckId}/notion-import`,
+    );
+  }
+
+  /**
+   * フロントが連携ボタンの表示出し分けに使用する。
+   */
+  @UseGuards(JwtAuthGuard)
+  @Get('status')
+  @ApiResponse({ status: 200, type: NotionStatusResponse })
+  async getStatus(@GetUserId() userId: string): Promise<NotionStatusResponse> {
+    const status = await this.notionOAuthService.getStatus(userId);
+    return new NotionStatusResponse(status.connected, status.workspaceName);
+  }
+
+  /**
+   * userIdのNotionIntegrationを削除
+   */
+  @UseGuards(JwtAuthGuard)
+  @Delete()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteIntegration(@GetUserId() userId: string): Promise<void> {
+    await this.notionOAuthService.deleteIntegration(userId);
+  }
+}

--- a/backend/src/integrations/notion/notion-oauth.cookies.ts
+++ b/backend/src/integrations/notion/notion-oauth.cookies.ts
@@ -1,0 +1,28 @@
+import express from 'express';
+
+/** CSRF対策用のランダムstate */
+export const COOKIE_OAUTH_STATE = 'oauth_state';
+/** 認可後の戻り先となるデッキID */
+export const COOKIE_OAUTH_DECK_ID = 'oauth_deck_id';
+/** callback時にuserIdを識別するためのID */
+export const COOKIE_OAUTH_USER_ID = 'oauth_user_id';
+
+/** state Cookieの有効期間（5分） */
+export const COOKIE_MAX_AGE = 5 * 60 * 1000;
+
+/**
+ * OAuth用Cookieをまとめて破棄する
+ *
+ * callback成功・失敗のいずれでも実行する（再利用防止のため）
+ */
+export function clearOAuthCookies(res: express.Response) {
+  const clearOptions: express.CookieOptions = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+  };
+  res.clearCookie(COOKIE_OAUTH_STATE, clearOptions);
+  res.clearCookie(COOKIE_OAUTH_DECK_ID, clearOptions);
+  res.clearCookie(COOKIE_OAUTH_USER_ID, clearOptions);
+}

--- a/backend/src/integrations/notion/notion-oauth.exception.filter.ts
+++ b/backend/src/integrations/notion/notion-oauth.exception.filter.ts
@@ -1,0 +1,50 @@
+import {
+  ArgumentsHost,
+  BadGatewayException,
+  BadRequestException,
+  Catch,
+  ExceptionFilter,
+  Logger,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+import {
+  COOKIE_OAUTH_DECK_ID,
+  clearOAuthCookies,
+} from './notion-oauth.cookies';
+
+@Catch(BadRequestException, BadGatewayException)
+export class NotionOAuthExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(NotionOAuthExceptionFilter.name);
+
+  catch(
+    exception: BadRequestException | BadGatewayException,
+    host: ArgumentsHost,
+  ) {
+    const ctx = host.switchToHttp();
+    const res: Response = ctx.getResponse<Response>();
+    const req = ctx.getRequest<Request>();
+
+    const cookies = req.cookies as Record<string, string | undefined>;
+    const deckId = cookies[COOKIE_OAUTH_DECK_ID] ?? '/decks';
+
+    // BADREQUESTに関してはクライアント由来であり調査の必要性が薄い。
+    if (exception instanceof BadGatewayException) {
+      this.logger.error(exception.message, exception.stack);
+    } else {
+      this.logger.warn(exception.message);
+    }
+
+    // cookieを破棄
+    clearOAuthCookies(res);
+
+    // notionからのリクエストから発生したエラーはフロントに返す必要がない。
+    // つまりサーバー内部エラーであるためメッセージは返さずフラグで失敗かどうかの判断をさせる。
+    const code =
+      exception instanceof BadGatewayException
+        ? 'notion_failed'
+        : 'notion_invalid';
+    return res.redirect(
+      `${process.env.FRONTEND_URL}/decks/${deckId}?integration=${code}`,
+    );
+  }
+}

--- a/backend/src/integrations/notion/notion-oauth.service.ts
+++ b/backend/src/integrations/notion/notion-oauth.service.ts
@@ -1,0 +1,146 @@
+import { BadGatewayException, Injectable } from '@nestjs/common';
+import { randomBytes } from 'crypto';
+import { NotionIntegrationRepository } from './notion-integration.repository';
+import { getEnv } from '../../common/functions/get-env';
+
+/**
+ * Notion OAuth tokenエンドポイントのレスポンス（必要項目のみ）
+ *
+ * Notionは workspace_icon, bot_id, owner なども返すが、本機能では保存しないため
+ * ここでは扱わない。
+ */
+export type NotionTokenResponse = {
+  access_token: string;
+  refresh_token: string;
+  workspace_id: string;
+  workspace_name: string;
+};
+@Injectable()
+export class NotionOAuthService {
+  // Notion OAuth関連のエンドポイント
+  private static readonly NOTION_AUTHORIZE_URL =
+    'https://api.notion.com/v1/oauth/authorize';
+  private static readonly NOTION_TOKEN_URL =
+    'https://api.notion.com/v1/oauth/token';
+
+  constructor(private readonly repository: NotionIntegrationRepository) {}
+
+  /**
+   * Notion認可画面へのリダイレクト先URLを構築する
+   * @param state /authで生成しCookieに保存したstate
+   */
+  buildAuthorizationUrl(state: string): string {
+    const url = new URL(NotionOAuthService.NOTION_AUTHORIZE_URL);
+    // query
+    url.searchParams.set('client_id', getEnv('NOTION_CLIENT_ID'));
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('owner', 'user');
+    url.searchParams.set('redirect_uri', getEnv('NOTION_REDIRECT_URI'));
+    url.searchParams.set('state', state);
+    return url.toString();
+  }
+
+  /**
+   * 認可codeをNotionのtokenエンドポイントに投げてAT/RTを取得する
+   * @param code Notionから返され認可code
+   * @returns Notionから送られたtoken（保存対象のみ抽出）
+   */
+  async exchangeCodeForTokens(code: string): Promise<NotionTokenResponse> {
+    const clientId = getEnv('NOTION_CLIENT_ID');
+    const clientSecret = getEnv('NOTION_CLIENT_SECRET');
+    const redirectUri = getEnv('NOTION_REDIRECT_URI');
+
+    // Basic認証ヘッダ用のbase64文字列
+    const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
+      'base64',
+    );
+
+    let response: Response;
+    try {
+      response = await fetch(NotionOAuthService.NOTION_TOKEN_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${credentials}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          grant_type: 'authorization_code', // Notionに認可codeだと知らせる
+          code,
+          redirect_uri: redirectUri,
+        }),
+      });
+    } catch (e) {
+      throw new BadGatewayException(e, 'Notionとの通信に失敗しました。');
+    }
+
+    if (!response.ok) {
+      // 認可エラー・期限切れ等。設計上は502相当として扱う。
+      throw new BadGatewayException('Notion連携に失敗しました。');
+    }
+
+    // Notionはbearer固定だが念のため型を合わせて使う
+    const body = (await response.json()) as Partial<NotionTokenResponse>;
+
+    // 必須項目の検証（Notion側のエラー対策）
+    if (
+      !body.access_token ||
+      !body.refresh_token ||
+      !body.workspace_id ||
+      !body.workspace_name
+    ) {
+      throw new BadGatewayException('Notionからのレスポンスが不正です。');
+    }
+    // NotionTokenResponseを返す
+    return {
+      access_token: body.access_token,
+      refresh_token: body.refresh_token,
+      workspace_id: body.workspace_id,
+      workspace_name: body.workspace_name,
+    };
+  }
+
+  /**
+   * 取得したAT/RTをDBへ保存する（upsert）
+   * 暗号化はrepositoryで行う。
+   */
+  async saveNotionResponse(userId: string, tokens: NotionTokenResponse) {
+    return this.repository.upsert({
+      userId,
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      workspaceId: tokens.workspace_id,
+      workspaceName: tokens.workspace_name,
+    });
+  }
+
+  /**
+   * 連携状態を返す
+   * - レコードが無ければ connected=false のみ
+   * - 有れば connected=true と workspaceName を返す
+   */
+  async getStatus(userId: string): Promise<{
+    connected: boolean;
+    workspaceName?: string;
+  }> {
+    const integration = await this.repository.findByUserId(userId);
+    if (!integration) {
+      return { connected: false };
+    }
+    return {
+      connected: true,
+      workspaceName: integration.workspaceName,
+    };
+  }
+
+  /**
+   * 連携解除
+   */
+  async deleteIntegration(userId: string): Promise<void> {
+    await this.repository.delete(userId);
+  }
+
+  /** 32バイトのランダムstateを生成する（hex 64文字）*/
+  generateState(): string {
+    return randomBytes(32).toString('hex');
+  }
+}

--- a/backend/src/integrations/notion/notion.module.ts
+++ b/backend/src/integrations/notion/notion.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../../auth/auth.module';
+import { EncryptionModule } from '../../common/encryption/encryption.module';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { NotionIntegrationRepository } from './notion-integration.repository';
+import { NotionOAuthController } from './notion-oauth.controller';
+import { NotionOAuthService } from './notion-oauth.service';
+
+@Module({
+  imports: [PrismaModule, EncryptionModule, AuthModule],
+  controllers: [NotionOAuthController],
+  providers: [NotionOAuthService, NotionIntegrationRepository],
+  exports: [NotionOAuthService, NotionIntegrationRepository],
+})
+export class NotionModule {}


### PR DESCRIPTION
## 概要
Notion機能の連携フローを実装。
Controller Service Repositoryの三層で実装し、RespositoryInterfaceは実装しない

Notion連携は以下のフローで成り立っている。

1. ユーザがNotion連携ボタンを押下
2. NotionのOAuth用のURIにリダイレクト
3. ユーザがNotion側で権限を許可
4. Notionが自サーバに認可コードとともにcallback
5. バックエンドで認可コードを用いてNotionにtoken要求
6. バックエンドがtokenを受け取りDBに暗号化して保存
7. tokenを使ってNotionAPIにリクエスト

という流れになる。

この流れの時必要になるのが
- /auth　2に該当
- /callback　5に該当


## 詳細
- RepositoryInterfaceを実装しなかった理由
単純に依存が少なかったからである。respositoryを呼び出す箇所はsaveNotionResponse, deleteState, getStatusの三つであり、getStatus以外は戻り値を扱わない。しかもgetStatusの戻り値はworkspaceNameだけであり、ほぼ影響がない。
よってテスト容易性もクリアしている。

→考え直したが、古いJavaの考えが悪い影響をしていたようだ。
現代のテストmockではRepositoryInterfaceを実装しなくても容易にモックできるようになっている、つまりテスト容易性は本質的な理由ではない。必要となるのはクリーンアーキテクチャ的に厳密に依存性の方向を調整したいとき、永続化を入れ替える予定があるときである。そのため、今回は全くもって必要ない。そして、Card機能のRepositoryInterfaceは失敗であることが分かった。

- stateが必要になる理由
被害者がnotion連携の認可を設定した後に攻撃者がリクエストが偽装してnotionからのcallbackへ向けて送られた場合、攻撃者は被害者のnotionをアプリを通してアクセスすることができる。
そのため、callbackに送られるリクエストが正規のユーザであることを確認する必要がある。そこでStateを持ちて検証を行っている。（cookieに保存するのだが、stateは漏洩してはいけないのでHTTPONLYを設定する。）

- cookieの破棄とリダイレクト
cookieにはuserIdやstateが含まれるため、callback終了後に破棄しないと攻撃の糸口にされてしまう。破棄の方針として、正常時はreturn前に破棄。異常時は独自filterでログ出力＋破棄。

- env読み込みの例外処理について
本来はenv読み込み時に例外処理すべきだが今まで行っていなかった。そこでgetEnv関数をcommonに作成して一括で例外処理＋読み取りを行えるように改造した。また、notionブランチが終わり次第main.tsで起動前に全体env読み込み確認。getEnvで個別確認を行うように修正する。

- repositoryでの暗号化について
serviceで暗号化すると、repositoryでも確認が必要になってしまう。また、DB保存のためのデータ整形はRepositoryの役割でもある。よってrepositoryで暗号化を進めた。

---
次はNotionAPIのデータ取得部分を進める。(refresh含む)