### PR TITLE
fix: Dockerfileのbuild順と開発用スクリプトをnpm ciから除外

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,10 +13,10 @@ RUN npm ci
 COPY shared ./shared
 COPY backend ./backend
 
+RUN npx prisma generate --schema=backend/prisma/schema.prisma
+
 RUN npm run build --workspace=@memo-anki/shared
 RUN npm run build --workspace=backend
-
-RUN npx prisma generate --schema=backend/prisma/schema.prisma
 
 # Stage 2: runner
 # 本番ランタイム。slimで軽量化、本番依存のみ
@@ -28,7 +28,7 @@ COPY package.json package-lock.json ./
 COPY shared/package.json shared/
 COPY backend/package.json backend/
 
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev --ignore-scripts 
 
 COPY --from=builder /app/shared/dist ./shared/dist
 COPY --from=builder /app/backend/dist ./backend/dist


### PR DESCRIPTION
修正点
- buildにはprismaの型を参照するため、build前にprismaの生成を実行するように変更
- npm ciにhuskyなどの開発用のスクリプトが含まれていたため、それらを除外。

普通にmainに統合できてしまったため、CIに加えてCDの必要性を感じた。
今後CDの追加も行っていく。

今回はローカルで動作確認済み