### PR TITLE
Feat/prediction per rating

### DIFF
--- a/backend/src/card/apply-rating.ts
+++ b/backend/src/card/apply-rating.ts
@@ -23,6 +23,7 @@ export type ReviewUpdate = {
   interval: number;
   easeFactor: number;
   nextReviewAt: Date;
+  intervalMs: number; // 採点プレビュー用の採点間隔
 };
 
 /**
@@ -57,6 +58,7 @@ export function applyRating(
         interval: card.interval,
         easeFactor: card.easeFactor,
         nextReviewAt: card.nextReviewAt,
+        intervalMs: 0, // 状態が変わらない＝待ち時間も伸びないので0
       };
   }
 }
@@ -77,6 +79,7 @@ function applyToNew(card: Card, rating: ReviewRating, now: Date): ReviewUpdate {
         interval: card.interval,
         easeFactor: card.easeFactor,
         nextReviewAt: addMs(now, 1 * ONE_MIN),
+        intervalMs: 1 * ONE_MIN,
       };
     case ReviewRating.HARD:
       // nextReviewAtを"10分後"に設定
@@ -86,6 +89,7 @@ function applyToNew(card: Card, rating: ReviewRating, now: Date): ReviewUpdate {
         interval: card.interval,
         easeFactor: card.easeFactor,
         nextReviewAt: addMs(now, 10 * ONE_MIN),
+        intervalMs: 10 * ONE_MIN,
       };
     case ReviewRating.GOOD:
       // SHORTへ昇格。repetitionをリセット。nextReviewAtを"1時間後"に設定
@@ -95,6 +99,7 @@ function applyToNew(card: Card, rating: ReviewRating, now: Date): ReviewUpdate {
         interval: card.interval,
         easeFactor: card.easeFactor,
         nextReviewAt: addMs(now, 1 * ONE_HOUR),
+        intervalMs: 1 * ONE_HOUR,
       };
     case ReviewRating.EASY:
       // LONGへ即昇格。SM-2の初期状態(rep=1, interval=1)に揃える。nextReviewAtを"1日後"に設定
@@ -104,6 +109,7 @@ function applyToNew(card: Card, rating: ReviewRating, now: Date): ReviewUpdate {
         interval: 1,
         easeFactor: card.easeFactor,
         nextReviewAt: addMs(now, 1 * ONE_DAY),
+        intervalMs: 1 * ONE_DAY,
       };
   }
 }
@@ -128,6 +134,7 @@ function applyToShort(
         interval: card.interval,
         easeFactor: card.easeFactor,
         nextReviewAt: addMs(now, 1 * ONE_MIN),
+        intervalMs: 1 * ONE_MIN,
       };
     case ReviewRating.HARD:
       // nextReviewAtを"10分後"に設定
@@ -137,6 +144,7 @@ function applyToShort(
         interval: card.interval,
         easeFactor: card.easeFactor,
         nextReviewAt: addMs(now, 10 * ONE_MIN),
+        intervalMs: 10 * ONE_MIN,
       };
     case ReviewRating.GOOD: {
       const nextRep = card.repetition + 1;
@@ -149,6 +157,7 @@ function applyToShort(
           interval: 1,
           easeFactor: card.easeFactor,
           nextReviewAt: addMs(now, 1 * ONE_DAY),
+          intervalMs: 1 * ONE_DAY,
         };
       }
       // 1回目のgoodでrepetition += 1, nextReviewAtを"1時間後"に設定
@@ -158,6 +167,7 @@ function applyToShort(
         interval: card.interval,
         easeFactor: card.easeFactor,
         nextReviewAt: addMs(now, 1 * ONE_HOUR),
+        intervalMs: 1 * ONE_HOUR,
       };
     }
     case ReviewRating.EASY:
@@ -168,6 +178,7 @@ function applyToShort(
         interval: 1,
         easeFactor: card.easeFactor,
         nextReviewAt: addMs(now, 1 * ONE_DAY),
+        intervalMs: 1 * ONE_DAY,
       };
   }
 }
@@ -197,6 +208,7 @@ function applyToLong(
         interval: 1,
         easeFactor: ef,
         nextReviewAt: addMs(now, 1 * ONE_MIN),
+        intervalMs: 1 * ONE_MIN,
       };
     }
     case ReviewRating.HARD: {
@@ -210,6 +222,7 @@ function applyToLong(
         interval: nextInterval,
         easeFactor: ef,
         nextReviewAt: addMs(now, nextInterval * ONE_DAY),
+        intervalMs: nextInterval * ONE_DAY,
       };
     }
     case ReviewRating.GOOD: {
@@ -223,6 +236,7 @@ function applyToLong(
         interval: nextInterval,
         easeFactor: ef,
         nextReviewAt: addMs(now, nextInterval * ONE_DAY),
+        intervalMs: nextInterval * ONE_DAY,
       };
     }
     case ReviewRating.EASY: {
@@ -237,6 +251,7 @@ function applyToLong(
         interval: nextInterval,
         easeFactor: ef,
         nextReviewAt: addMs(now, nextInterval * ONE_DAY),
+        intervalMs: nextInterval * ONE_DAY,
       };
     }
   }

--- a/backend/src/card/card.controller.ts
+++ b/backend/src/card/card.controller.ts
@@ -115,11 +115,14 @@ export class CardController {
     @GetUserId() userId: string,
     @Query('deckId', ParseBigIntIdPipe) deckId: string,
   ) {
+    // service は {card, preview} の配列を返す。
     const responses = await this.reviewService.findReviewCards({
       deckId,
       userId,
     });
-    return responses.map((card) => new CardReviewResponse(card));
+    return responses.map(
+      ({ card, preview }) => new CardReviewResponse(card, preview),
+    );
   }
 
   /** 採点を反映する */

--- a/backend/src/card/dto/card-review.response.ts
+++ b/backend/src/card/dto/card-review.response.ts
@@ -1,6 +1,38 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Card } from '@prisma/client';
 import { CardType } from '@memo-anki/shared';
+
+/**
+ * 採点ボタンに表示する次回復習時間(ms)のプレビュー。
+ * フロントは "+1分" "+1日" などに整形して各ボタン内に表示する。
+ * swaggerの都合でtypeでなくclassにして型共有する
+ */
+export class ReviewPreviewResponse {
+  @ApiProperty({
+    example: 60000,
+    description: 'AGAINを押した時の次回待ち時間(ms)',
+  })
+  again: number;
+
+  @ApiProperty({
+    example: 600000,
+    description: 'HARDを押した時の次回待ち時間(ms)',
+  })
+  hard: number;
+
+  @ApiProperty({
+    example: 3600000,
+    description: 'GOODを押した時の次回待ち時間(ms)',
+  })
+  good: number;
+
+  @ApiProperty({
+    example: 86400000,
+    description: 'EASYを押した時の次回待ち時間(ms)',
+  })
+  easy: number;
+}
+
 /** 復習キュー用レスポンス（楽観ロックのversionをフロントが採点時に返送する） */
 export class CardReviewResponse {
   @ApiProperty({ example: '1' })
@@ -45,7 +77,11 @@ export class CardReviewResponse {
   @ApiProperty({ example: 0, description: '楽観ロック用バージョン' })
   version: number;
 
-  constructor(card: Card) {
+  // findReviewCards経由のときだけ詰める。
+  @ApiPropertyOptional({ type: ReviewPreviewResponse })
+  preview?: ReviewPreviewResponse;
+
+  constructor(card: Card, preview?: ReviewPreviewResponse) {
     // FK PKはNOT NULL制約のため異常発生してもここに来る前にエラー
     this.id = card.id?.toString();
     this.deckId = card.deckId?.toString();
@@ -57,5 +93,6 @@ export class CardReviewResponse {
     this.queue = card.queue;
     this.nextReviewAt = card.nextReviewAt;
     this.version = card.version;
+    this.preview = preview;
   }
 }

--- a/backend/src/card/dto/card.response.ts
+++ b/backend/src/card/dto/card.response.ts
@@ -39,6 +39,9 @@ export class CardResponse {
   @ApiProperty({ example: '2024-01-01T00:00:00.000Z' })
   updatedAt: Date;
 
+  @ApiProperty({ example: '2024-01-01T00:00:00.000Z' })
+  nextReviewAt: Date;
+
   constructor(card: Card) {
     // FK PKはNOT NULL制約のため異常発生してもここに来る前にエラー
     this.id = card.id?.toString();
@@ -49,5 +52,6 @@ export class CardResponse {
     this.question = card.question; // 明確にnullにしたい
     this.answer = card.answer; // 明確にnullにしたい
     this.updatedAt = card.updatedAt;
+    this.nextReviewAt = card.nextReviewAt;
   }
 }

--- a/backend/src/card/review.service.ts
+++ b/backend/src/card/review.service.ts
@@ -24,6 +24,20 @@ export type ReviewCardDto = {
   version: number;
 };
 
+/** 採点ボタンに表示する次回復習時間(ミリ秒)のプレビュー値。*/
+export type ReviewPreview = {
+  again: number;
+  hard: number;
+  good: number;
+  easy: number;
+};
+
+/** 復習キューの1要素: カード本体と4つの採点プレビュー */
+export type ReviewQueueItem = {
+  card: Card;
+  preview: ReviewPreview;
+};
+
 @Injectable()
 export class ReviewService {
   constructor(
@@ -33,9 +47,9 @@ export class ReviewService {
   ) {}
   /**
    * 復習キューを取得する
-   * @returns ソートされたCard10件
+   * @returns ソートされたカード10件 + 採点プレビュー
    */
-  async findReviewCards(dto: GetReviewCardDto) {
+  async findReviewCards(dto: GetReviewCardDto): Promise<ReviewQueueItem[]> {
     // PrismaのInput型がないのでdtoのままRepositoryへ渡す。
     const { deckId, userId } = dto;
 
@@ -49,7 +63,18 @@ export class ReviewService {
     );
     // カードを並び替え
     const sortedQueue: Card[] = sortReviewQueue(reviewCards);
-    return sortedQueue;
+
+    // 並び替え後のカードそれぞれに対し4採点分の次回待ち時間(ms)を計算。
+    const now = new Date();
+    return sortedQueue.map((card) => ({
+      card,
+      preview: {
+        again: applyRating(card, ReviewRating.AGAIN, now).intervalMs,
+        hard: applyRating(card, ReviewRating.HARD, now).intervalMs,
+        good: applyRating(card, ReviewRating.GOOD, now).intervalMs,
+        easy: applyRating(card, ReviewRating.EASY, now).intervalMs,
+      },
+    }));
   }
 
   /**

--- a/frontend/app/(main)/decks/[deckId]/review/page.tsx
+++ b/frontend/app/(main)/decks/[deckId]/review/page.tsx
@@ -97,6 +97,7 @@ export default function ReviewPage() {
       }}
       // quizかつ回答が表示されているときtrue(ボタン有効化)
       ratingDisabled={isQuiz && !answerShown}
+      preview={current.preview}
     >
       {/* children */}
       {isQuiz ? (

--- a/frontend/features/card/components/CardList.tsx
+++ b/frontend/features/card/components/CardList.tsx
@@ -27,8 +27,12 @@ export default function CardList({ cards, onEdit, onDelete }: CardListProps) {
       >
         <span>カード名 / タイプ</span>
         <span className="hidden md:block">詳細</span>
-        <span className="hidden md:block">作成日時</span>
-        <span />
+        <span className="hidden md:block">次回復習日時</span>
+        {/* ボタン列の幅をRowと合わせるための透明ダミー */}
+        <span className="flex gap-2 shrink-0 invisible" aria-hidden="true">
+          <span className="w-15"></span>
+          <span className="w-15"></span>
+        </span>
       </div>
 
       {/* 行 */}

--- a/frontend/features/card/components/CardRow.tsx
+++ b/frontend/features/card/components/CardRow.tsx
@@ -14,7 +14,7 @@ type CardRowProps = {
 
 export default function CardRow({ card, onEdit, onDelete }: CardRowProps) {
   const detail = buildCardDetail(card);
-  const date = formatDate(card.updatedAt);
+  const date = formatDate(card.nextReviewAt);
 
   return (
     <li
@@ -39,7 +39,7 @@ export default function CardRow({ card, onEdit, onDelete }: CardRowProps) {
         {detail}
       </div>
 
-      {/* 日時（md以上で表示） */}
+      {/* 次回復習日時（md以上で表示） */}
       <div className="hidden md:block text-[12px] text-gray-400 whitespace-nowrap">
         {date}
       </div>

--- a/frontend/features/review/components/ReviewLayout.tsx
+++ b/frontend/features/review/components/ReviewLayout.tsx
@@ -7,6 +7,9 @@ import { CardType, ReviewRating } from '@memo-anki/shared';
 
 import CardTypeBadge from '@/features/card/components/CardTypeBadge';
 import ReviewRatingButtons from './ReviewRatingButtons';
+import type { components } from '@memo-anki/shared';
+type ReviewPreviewResponse =
+  components['schemas']['CardReviewResponse']['preview'];
 
 type ReviewLayoutProps = {
   deckId: string;
@@ -15,6 +18,7 @@ type ReviewLayoutProps = {
   cardType: CardType;
   onRating: (rating: ReviewRating) => void;
   ratingDisabled?: boolean;
+  preview: ReviewPreviewResponse;
   /** カード本文 + 回答などのカード中身。NOTE/QUIZ で差し替える。 */
   children: ReactNode;
 };
@@ -26,6 +30,7 @@ export default function ReviewLayout({
   cardType,
   onRating,
   ratingDisabled = false,
+  preview,
   children,
 }: ReviewLayoutProps) {
   return (
@@ -65,6 +70,7 @@ export default function ReviewLayout({
             <ReviewRatingButtons
               onRating={onRating}
               disabled={ratingDisabled}
+              preview={preview}
             />
           </div>
         </section>

--- a/frontend/features/review/components/ReviewRatingButtons.tsx
+++ b/frontend/features/review/components/ReviewRatingButtons.tsx
@@ -1,16 +1,28 @@
 'use client';
 
 import { ReviewRating } from '@memo-anki/shared';
+import type { components } from '@memo-anki/shared';
+type ReviewPreviewResponse =
+  components['schemas']['CardReviewResponse']['preview'];
 
 // disabledはquizの回答表示前に設定する
 type ReviewRatingButtonsProps = {
   onRating: (rating: ReviewRating) => void;
   disabled?: boolean;
+  preview: ReviewPreviewResponse;
 };
+
+/** ミリ秒を "1分" "10分" "1時間" "1日" などの日本語に整形する */
+function formatMs(ms: number): string {
+  if (ms < 60 * 60 * 1000) return `${Math.round(ms / 60000)}分`;
+  if (ms < 24 * 60 * 60 * 1000) return `${Math.round(ms / 3600000)}時間`;
+  return `${Math.round((ms / 86400000) * 10) / 10}日`; // sm2は整数にはならない
+}
 
 export default function ReviewRatingButtons({
   onRating,
   disabled = false,
+  preview,
 }: ReviewRatingButtonsProps) {
   return (
     <div className="flex items-stretch gap-2.5">
@@ -20,7 +32,8 @@ export default function ReviewRatingButtons({
         disabled={disabled}
         className="btn btn-error flex-1 h-16 text-white text-[14px] font-bold"
       >
-        Again
+        Again <br />
+        {preview && `> ${formatMs(preview.again)}`}
       </button>
       <button
         type="button"
@@ -28,7 +41,8 @@ export default function ReviewRatingButtons({
         disabled={disabled}
         className="btn btn-warning flex-1 h-16 text-white text-[14px] font-bold"
       >
-        Hard
+        Hard <br />
+        {preview && `> ${formatMs(preview.hard)}`}
       </button>
       <button
         type="button"
@@ -36,7 +50,8 @@ export default function ReviewRatingButtons({
         disabled={disabled}
         className="btn btn-success flex-1 h-16 text-white text-[14px] font-bold"
       >
-        Good
+        Good <br />
+        {preview && `> ${formatMs(preview.good)}`}
       </button>
       <button
         type="button"
@@ -44,7 +59,8 @@ export default function ReviewRatingButtons({
         disabled={disabled}
         className="btn btn-info flex-1 h-16 text-white text-[14px] font-bold"
       >
-        Easy
+        Easy <br />
+        {preview && `> ${formatMs(preview.easy)}`}
       </button>
     </div>
   );

--- a/shared/src/api.ts
+++ b/shared/src/api.ts
@@ -284,6 +284,11 @@ export interface components {
              * @example 2024-01-01T00:00:00.000Z
              */
             updatedAt: string;
+            /**
+             * Format: date-time
+             * @example 2024-01-01T00:00:00.000Z
+             */
+            nextReviewAt: string;
         };
         /**
          * @description 0=AGAIN, 1=HARD, 2=GOOD, 3=EASY

--- a/shared/src/api.ts
+++ b/shared/src/api.ts
@@ -302,6 +302,28 @@ export interface components {
              */
             version: number;
         };
+        ReviewPreviewResponse: {
+            /**
+             * @description AGAINを押した時の次回待ち時間(ms)
+             * @example 60000
+             */
+            again: number;
+            /**
+             * @description HARDを押した時の次回待ち時間(ms)
+             * @example 600000
+             */
+            hard: number;
+            /**
+             * @description GOODを押した時の次回待ち時間(ms)
+             * @example 3600000
+             */
+            good: number;
+            /**
+             * @description EASYを押した時の次回待ち時間(ms)
+             * @example 86400000
+             */
+            easy: number;
+        };
         CardReviewResponse: {
             /** @example 1 */
             id: string;
@@ -332,6 +354,7 @@ export interface components {
              * @example 0
              */
             version: number;
+            preview?: components["schemas"]["ReviewPreviewResponse"];
         };
     };
     responses: never;


### PR DESCRIPTION
## 概要
復習画面の採点ボタンに次回復習時間が表示されるように機能追加
カード一覧画面に次回復習日時が表示されるように機能追加

これらの機能追加により、ユーザの復習の手ごたえをより感じやすくさせた。

## 詳細
- apply-ratingは復習ロジックの根幹なため、できるだけ触らないようにカラムを一つ追加する変更に留めた。
- バックエンドでは純粋なmsで送り、フロントエンドで「1日後」などに整形する方針にした。
- 復習キュー取得時にnextReviewAtを４通り計算しているため、採点エンドポイントで採点する必要はないが、変更が大きくなるため却下。リファクタするとしたらNotion連携が完成してから。
- カード作成日時を廃止して、次回復習日時に変更。カラムの列ずれも修正。