### PR TITLE
Feat/notion replace to sdk

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.3.2",
     "@nestjs/throttler": "^6.5.0",
+    "@notionhq/client": "^5.22.0",
     "@prisma/client": "^6.19.2",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",

--- a/backend/src/integrations/notion/dto/notion-auth-start.response.ts
+++ b/backend/src/integrations/notion/dto/notion-auth-start.response.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * /auth レスポンス
+ *
+ * フロントはこの url を window.location.href にセットして Notion 認可画面へ遷移する。
+ */
+export class NotionAuthStartResponse {
+  @ApiProperty({
+    example:
+      'https://api.notion.com/v1/oauth/authorize?client_id=...&response_type=code&owner=user&redirect_uri=...&state=...',
+    description: 'Notion認可画面のURL。フロントはこのURLへブラウザ遷移する。',
+  })
+  url: string;
+
+  constructor(url: string) {
+    this.url = url;
+  }
+}

--- a/backend/src/integrations/notion/notion-oauth.controller.spec.ts
+++ b/backend/src/integrations/notion/notion-oauth.controller.spec.ts
@@ -116,7 +116,7 @@ describe('NotionOAuthController.callback', () => {
 
       // import画面へredirect
       expect(res.redirect).toHaveBeenCalledWith(
-        'http://localhost:3000/decks/deck-99/notion-import',
+        'http://localhost:3000/decks/deck-99?integration=notion_success',
       );
     });
   });

--- a/backend/src/integrations/notion/notion-oauth.controller.ts
+++ b/backend/src/integrations/notion/notion-oauth.controller.ts
@@ -15,6 +15,7 @@ import { ApiResponse } from '@nestjs/swagger';
 import express from 'express';
 import { JwtAuthGuard } from '../../auth/jwt.guard';
 import { GetUserId } from '../../common/decorators/get-userid.decorator';
+import { NotionAuthStartResponse } from './dto/notion-auth-start.response';
 import { NotionStatusResponse } from './dto/notion-status.response';
 import {
   NotionOAuthService,
@@ -41,11 +42,12 @@ export class NotionOAuthController {
    */
   @UseGuards(JwtAuthGuard)
   @Get('auth')
+  @ApiResponse({ status: 200, type: NotionAuthStartResponse })
   startAuth(
     @GetUserId() userId: string,
     @Query('deckId') deckId: string | undefined,
-    @Res() res: express.Response,
-  ) {
+    @Res({ passthrough: true }) res: express.Response,
+  ): NotionAuthStartResponse {
     // deckIdは認可後のフロント遷移先に使うため必須
     if (!deckId) throw new BadRequestException('deckId は必須です。');
 
@@ -63,10 +65,10 @@ export class NotionOAuthController {
     res.cookie(COOKIE_OAUTH_DECK_ID, deckId, cookieOptions);
     res.cookie(COOKIE_OAUTH_USER_ID, userId, cookieOptions);
 
-    // Notion認可画面へ302リダイレクト
+    // Notion認可画面URLを返す（フロントがwindow.location.hrefで遷移する）
     const authorizationUrl =
       this.notionOAuthService.buildAuthorizationUrl(state);
-    return res.redirect(authorizationUrl);
+    return new NotionAuthStartResponse(authorizationUrl);
   }
 
   /**
@@ -132,7 +134,7 @@ export class NotionOAuthController {
     // フロントのimport画面へredirect
     return res.redirect(
       // urlは適当に決めた、フロント作成時に変更
-      `${frontendUrl}/decks/${deckId}/notion-import`,
+      `${frontendUrl}/decks/${deckId}?integration=notion_success`,
     );
   }
 

--- a/backend/src/integrations/notion/notion-oauth.exception.filter.ts
+++ b/backend/src/integrations/notion/notion-oauth.exception.filter.ts
@@ -30,6 +30,11 @@ export class NotionOAuthExceptionFilter implements ExceptionFilter {
     // BADREQUESTに関してはクライアント由来であり調査の必要性が薄い。
     if (exception instanceof BadGatewayException) {
       this.logger.error(exception.message, exception.stack);
+      // cause walk: SDK元エラー（APIResponseError等）も出す
+      const cause = (exception as Error).cause;
+      if (cause instanceof Error) {
+        this.logger.error(`Caused by: ${cause.message}`, cause.stack);
+      }
     } else {
       this.logger.warn(exception.message);
     }

--- a/backend/src/integrations/notion/notion-oauth.service.spec.ts
+++ b/backend/src/integrations/notion/notion-oauth.service.spec.ts
@@ -6,16 +6,44 @@ import {
   it,
   expect,
   beforeEach,
-  afterEach,
   vi,
   beforeAll,
   afterAll,
 } from 'vitest';
 import { BadGatewayException } from '@nestjs/common';
 import type { NotionIntegration } from '@prisma/client';
+import {
+  APIResponseError,
+  RequestTimeoutError,
+  type OauthTokenResponse,
+} from '@notionhq/client';
 
 import { NotionOAuthService } from './notion-oauth.service';
 import { NotionIntegrationRepository } from './notion-integration.repository';
+
+/**
+ * @notionhq/client (Notion 公式 SDK) のモック
+ * - 実 HTTP は飛ばしたいので Client.oauth.token を vi.fn() に差し替える
+ * - 各テストでは mockOauthToken.mockResolvedValue / mockRejectedValue を切り替えて使う
+ */
+const { mockOauthToken } = vi.hoisted(() => ({
+  mockOauthToken: vi.fn(),
+}));
+
+// Client は new で呼ばれるので class で差し替える。
+// APIResponseError 等のエラークラスは instanceof 判定に使うので、実物を importActual で残す
+vi.mock('@notionhq/client', async () => {
+  const actual =
+    await vi.importActual<typeof import('@notionhq/client')>(
+      '@notionhq/client',
+    );
+  return {
+    ...actual,
+    Client: class {
+      oauth = { token: mockOauthToken };
+    },
+  };
+});
 
 /**
  * NotionOAuthService の単体試験
@@ -64,43 +92,44 @@ describe('NotionOAuthService', () => {
     }).compile();
 
     service = module.get<NotionOAuthService>(NotionOAuthService);
+    // SDK モックの実装と呼び出し履歴を毎回リセット（前テストの mockResolvedValue を引きずらない）
+    mockOauthToken.mockReset();
     vi.clearAllMocks();
   });
 
-  afterEach(() => {
-    // fetch を都度 mock するため、各テスト後に必ず元へ戻す
-    vi.restoreAllMocks();
-  });
+  /**
+   * SDK の OauthTokenResponse は workspace_icon / bot_id / owner / token_type 等の必須項目を
+   * 多く含むが、service 側ではこれら 4 項目しか参照しないため、テストでは Partial を
+   * OauthTokenResponse としてキャストして渡す。
+   */
+  const buildOauthResponse = (
+    overrides: Partial<OauthTokenResponse>,
+  ): OauthTokenResponse =>
+    ({
+      access_token: 'AT',
+      refresh_token: 'RT',
+      workspace_id: 'ws',
+      workspace_name: 'name',
+      ...overrides,
+    }) as OauthTokenResponse;
 
   // ---------------------------------------------------------------------------
   // exchangeCodeForTokens
   // ---------------------------------------------------------------------------
   describe('exchangeCodeForTokens', () => {
-    /**
-     * Notion の token エンドポイントの 200 レスポンスを模した body を返す
-     * fetch 全体の mock を仕込むユーティリティ
-     */
-    const mockFetchJson = (status: number, body: unknown) => {
-      const fetchMock = vi.fn().mockResolvedValue({
-        ok: status >= 200 && status < 300,
-        status,
-        json: () => body,
-      });
-      vi.stubGlobal('fetch', fetchMock);
-      return fetchMock;
-    };
-
-    it('正常系: 200で必要項目が揃ったレスポンス → 4項目だけ抽出して返すこと', async () => {
-      // Notion が返す余分なフィールド (workspace_icon 等) は捨てる仕様
-      mockFetchJson(200, {
-        access_token: 'AT-xxx',
-        refresh_token: 'RT-xxx',
-        workspace_id: 'ws-1',
-        workspace_name: 'My Workspace',
-        workspace_icon: 'should-be-ignored',
-        bot_id: 'should-be-ignored',
-        token_type: 'bearer',
-      });
+    it('正常系: SDKが返したレスポンスから 4項目だけ抽出して返すこと', async () => {
+      // SDK レスポンスには workspace_icon / bot_id 等も含まれるが service は捨てる仕様
+      mockOauthToken.mockResolvedValue(
+        buildOauthResponse({
+          access_token: 'AT-xxx',
+          refresh_token: 'RT-xxx',
+          workspace_id: 'ws-1',
+          workspace_name: 'My Workspace',
+          workspace_icon: 'should-be-ignored',
+          bot_id: 'should-be-ignored',
+          token_type: 'bearer',
+        }),
+      );
 
       const result = await service.exchangeCodeForTokens('dummy-code');
 
@@ -113,84 +142,68 @@ describe('NotionOAuthService', () => {
       });
     });
 
-    it('呼び出し検証: URL / Basic認証ヘッダ / body が仕様通りであること', async () => {
-      const fetchMock = mockFetchJson(200, {
-        access_token: 'AT',
-        refresh_token: 'RT',
-        workspace_id: 'ws',
-        workspace_name: 'name',
-      });
+    it('呼び出し検証: oauth.token に grant_type/code/redirect_uri/client_id/client_secret が渡されること', async () => {
+      // URL や Basic 認証ヘッダの組み立ては SDK 側の責務になったので、
+      // service 単体テストでは「SDK に正しい引数を渡したか」のみを検証する
+      mockOauthToken.mockResolvedValue(buildOauthResponse({}));
 
       await service.exchangeCodeForTokens('code-123');
 
-      // base64(<client_id>:<client_secret>) を組み立てて比較
-      const expectedBasic = Buffer.from(
-        'test-client-id:test-client-secret',
-      ).toString('base64');
-
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-
-      // URL
-      expect(url).toBe('https://api.notion.com/v1/oauth/token');
-      // method
-      expect(init.method).toBe('POST');
-      // headers
-      expect(init.headers).toMatchObject({
-        Authorization: `Basic ${expectedBasic}`,
-        'Content-Type': 'application/json',
-      });
-      // body は JSON 文字列で、grant_type / code / redirect_uri が乗ること
-      expect(JSON.parse(init.body as string)).toEqual({
+      expect(mockOauthToken).toHaveBeenCalledTimes(1);
+      expect(mockOauthToken).toHaveBeenCalledWith({
         grant_type: 'authorization_code',
         code: 'code-123',
         redirect_uri: 'http://localhost:3001/api/integrations/notion/callback',
+        client_id: 'test-client-id',
+        client_secret: 'test-client-secret',
       });
     });
 
-    it('異常系: fetch 自体が throw → BadGatewayException', async () => {
-      // ネットワーク断などで fetch が rejected promise を返すケース
-      vi.stubGlobal(
-        'fetch',
-        vi.fn().mockRejectedValue(new Error('network down')),
+    // APIResponseError は Notion 側エラー（invalid_grant等）。service は内部用 message で投げ直す
+    it('異常系: APIResponseError → BadGateway (内部用 message / cause 保持)', async () => {
+      const apiErr = new APIResponseError({
+        code: 'unauthorized' as never,
+        status: 401,
+        message: 'invalid_grant',
+        headers: new Headers(),
+        rawBodyText: '{"error":"invalid_grant"}',
+        additional_data: undefined,
+        request_id: undefined,
+      });
+      mockOauthToken.mockRejectedValue(apiErr);
+
+      await expect(service.exchangeCodeForTokens('code')).rejects.toMatchObject(
+        {
+          constructor: BadGatewayException,
+          message: 'Notion連携に失敗しました。',
+          cause: apiErr,
+        },
       );
-
-      await expect(
-        service.exchangeCodeForTokens('code'),
-      ).rejects.toBeInstanceOf(BadGatewayException);
     });
 
-    it('異常系: response.ok=false (4xx/5xx) → BadGatewayException', async () => {
-      mockFetchJson(400, { error: 'invalid_grant' });
+    // それ以外（RequestTimeoutError / network 系）は通信用 message で投げ直す
+    it('異常系: RequestTimeoutError → BadGateway (通信用 message / cause 保持)', async () => {
+      const timeoutErr = new RequestTimeoutError('request timed out');
+      mockOauthToken.mockRejectedValue(timeoutErr);
 
-      await expect(
-        service.exchangeCodeForTokens('code'),
-      ).rejects.toBeInstanceOf(BadGatewayException);
+      await expect(service.exchangeCodeForTokens('code')).rejects.toMatchObject(
+        {
+          constructor: BadGatewayException,
+          message: 'Notionへの接続に失敗しました。',
+          cause: timeoutErr,
+        },
+      );
     });
 
-    // 必須項目欠落のパターンを it.each で網羅
-    it.each([
-      [
-        'access_token 欠落',
-        { refresh_token: 'r', workspace_id: 'w', workspace_name: 'n' },
-      ],
-      [
-        'refresh_token 欠落',
-        { access_token: 'a', workspace_id: 'w', workspace_name: 'n' },
-      ],
-      [
-        'workspace_id 欠落',
-        { access_token: 'a', refresh_token: 'r', workspace_name: 'n' },
-      ],
-      [
-        'workspace_name 欠落',
-        { access_token: 'a', refresh_token: 'r', workspace_id: 'w' },
-      ],
+    // OauthTokenResponse 型上、refresh_token と workspace_name は nullable。
+    // access_token / workspace_id は SDK 型で non-null 保証されているため runtime チェック不要
+    it.each<[string, Partial<OauthTokenResponse>]>([
+      ['refresh_token が null', { refresh_token: null, workspace_name: 'n' }],
+      ['workspace_name が null', { refresh_token: 'r', workspace_name: null }],
     ])(
       '異常系: 必須項目欠落 (%s) → BadGatewayException',
-      async (_label, body) => {
-        // [試験項目: exchange レスポンス必須項目欠落]
-        mockFetchJson(200, body);
+      async (_label, partial) => {
+        mockOauthToken.mockResolvedValue(buildOauthResponse(partial));
 
         await expect(
           service.exchangeCodeForTokens('code'),

--- a/backend/src/integrations/notion/notion-oauth.service.ts
+++ b/backend/src/integrations/notion/notion-oauth.service.ts
@@ -2,6 +2,11 @@ import { BadGatewayException, Injectable } from '@nestjs/common';
 import { randomBytes } from 'crypto';
 import { NotionIntegrationRepository } from './notion-integration.repository';
 import { getEnv } from '../../common/functions/get-env';
+import {
+  Client,
+  APIResponseError,
+  type OauthTokenResponse,
+} from '@notionhq/client';
 
 /**
  * Notion OAuth tokenエンドポイントのレスポンス（必要項目のみ）
@@ -20,8 +25,6 @@ export class NotionOAuthService {
   // Notion OAuth関連のエンドポイント
   private static readonly NOTION_AUTHORIZE_URL =
     'https://api.notion.com/v1/oauth/authorize';
-  private static readonly NOTION_TOKEN_URL =
-    'https://api.notion.com/v1/oauth/token';
 
   constructor(private readonly repository: NotionIntegrationRepository) {}
 
@@ -46,56 +49,39 @@ export class NotionOAuthService {
    * @returns Notionから送られたtoken（保存対象のみ抽出）
    */
   async exchangeCodeForTokens(code: string): Promise<NotionTokenResponse> {
-    const clientId = getEnv('NOTION_CLIENT_ID');
-    const clientSecret = getEnv('NOTION_CLIENT_SECRET');
-    const redirectUri = getEnv('NOTION_REDIRECT_URI');
+    const notion = new Client();
 
-    // Basic認証ヘッダ用のbase64文字列
-    const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
-      'base64',
-    );
-
-    let response: Response;
+    let response: OauthTokenResponse;
     try {
-      response = await fetch(NotionOAuthService.NOTION_TOKEN_URL, {
-        method: 'POST',
-        headers: {
-          Authorization: `Basic ${credentials}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          grant_type: 'authorization_code', // Notionに認可codeだと知らせる
-          code,
-          redirect_uri: redirectUri,
-        }),
+      response = await notion.oauth.token({
+        grant_type: 'authorization_code', // Notionに認可codeだと知らせる
+        code,
+        redirect_uri: getEnv('NOTION_REDIRECT_URI'),
+        client_id: getEnv('NOTION_CLIENT_ID'),
+        client_secret: getEnv('NOTION_CLIENT_SECRET'),
       });
     } catch (e) {
-      throw new BadGatewayException(e, 'Notionとの通信に失敗しました。');
+      // APIResponseError: Notion 側 4xx/5xx ／ それ以外: 通信系
+      if (e instanceof APIResponseError) {
+        throw new BadGatewayException('Notion連携に失敗しました。', {
+          cause: e,
+        });
+      }
+      throw new BadGatewayException('Notionへの接続に失敗しました。', {
+        cause: e,
+      });
     }
-
-    if (!response.ok) {
-      // 認可エラー・期限切れ等。設計上は502相当として扱う。
-      throw new BadGatewayException('Notion連携に失敗しました。');
-    }
-
-    // Notionはbearer固定だが念のため型を合わせて使う
-    const body = (await response.json()) as Partial<NotionTokenResponse>;
-
-    // 必須項目の検証（Notion側のエラー対策）
-    if (
-      !body.access_token ||
-      !body.refresh_token ||
-      !body.workspace_id ||
-      !body.workspace_name
-    ) {
+    // resがnullableなのでチェック
+    if (!response.refresh_token || !response.workspace_name) {
       throw new BadGatewayException('Notionからのレスポンスが不正です。');
     }
+
     // NotionTokenResponseを返す
     return {
-      access_token: body.access_token,
-      refresh_token: body.refresh_token,
-      workspace_id: body.workspace_id,
-      workspace_name: body.workspace_name,
+      access_token: response.access_token,
+      refresh_token: response.refresh_token,
+      workspace_id: response.workspace_id,
+      workspace_name: response.workspace_name,
     };
   }
 

--- a/frontend/app/(main)/decks/[deckId]/page.tsx
+++ b/frontend/app/(main)/decks/[deckId]/page.tsx
@@ -13,6 +13,7 @@ import CardCreateModal from '@/features/card/components/CardCreateModal';
 import CardEditModal from '@/features/card/components/CardEditModal';
 import DeckUpdateModal from '@/features/deck/components/DeckUpdateModal';
 import { useDeckMutations } from '@/features/deck/hooks/useDeckMutations';
+import { useNotionAuth } from '@/features/integration/notion/hooks/useNotionAuth';
 
 type Card = components['schemas']['CardResponse'];
 type CreateCardRequest = components['schemas']['CreateCardRequest'];
@@ -40,6 +41,7 @@ export default function CardListPage() {
   const { data: cards = [], isLoading, isError, error } = useCards(deckId);
   const { createCard, updateCard, deleteCard } = useCardMutations();
   const { updateDeck } = useDeckMutations();
+  const { connect: connectNotion } = useNotionAuth(deckId);
 
   // useState（モーダル開閉）
   const [openEditDeck, setOpenEditDeck] = useState(false);
@@ -78,6 +80,7 @@ export default function CardListPage() {
             deckName={deck?.name ?? ''}
             onEditDeck={() => setOpenEditDeck(true)}
             onCreateCard={() => setOpenCreateCard(true)}
+            onConnectNotion={() => connectNotion.mutate()}
           />
           <CardList
             cards={cards}

--- a/frontend/features/card/components/CardListPageHeader.tsx
+++ b/frontend/features/card/components/CardListPageHeader.tsx
@@ -6,12 +6,14 @@ type CardListPageHeaderProps = {
   deckName: string;
   onEditDeck: () => void;
   onCreateCard: () => void;
+  onConnectNotion: () => void;
 };
 
 export default function CardListPageHeader({
   deckName,
   onEditDeck,
   onCreateCard,
+  onConnectNotion,
 }: CardListPageHeaderProps) {
   return (
     <div className="flex items-center justify-between px-8 py-5 border-b border-gray-200">
@@ -27,14 +29,19 @@ export default function CardListPageHeader({
         <h1 className="text-[20px] font-bold text-gray-900">カード一覧</h1>
       </div>
 
-      {/* 右：デッキ編集 + カード追加 */}
+      {/* 右：デッキ編集 + Notion連携 + カード追加 */}
       <div className="flex items-center gap-2">
+        <button onClick={onConnectNotion} className="btn btn-neutral btn-sm">
+          Notion連携
+        </button>
+
         <button
           onClick={onEditDeck}
           className="btn btn-outline btn-primary btn-sm"
         >
           デッキ編集
         </button>
+
         <button onClick={onCreateCard} className="btn btn-primary btn-sm">
           ＋ カード追加
         </button>

--- a/frontend/features/integration/notion/hooks/useNotionAuth.ts
+++ b/frontend/features/integration/notion/hooks/useNotionAuth.ts
@@ -1,0 +1,45 @@
+import { apiClient } from '@/lib/api/client';
+import { useMutation } from '@tanstack/react-query';
+import { components } from '@memo-anki/shared';
+import { HttpStatus } from '@/lib/api/statusCodes';
+import { toast } from 'sonner';
+import { HttpError } from '@/lib/api/httpError';
+type NotionAuthStartResponse = components['schemas']['NotionAuthStartResponse'];
+
+/**
+ * Notion OAuth 開始フック
+ *
+ * Notion連携ボタンが押されたら、このロジックが起動する。
+ * このロジックは/authに接続し、/authはNotionに渡すための情報を
+ * 含めたリダイレクトURLを発行するので、そのURLを使ってNotion側の
+ * 認証画面に移動する。
+ */
+export const useNotionAuth = (deckId: string) => {
+  const connect = useMutation<NotionAuthStartResponse>({
+    mutationFn: () =>
+      apiClient(
+        `/integrations/notion/auth?deckId=${encodeURIComponent(deckId)}`,
+        'GET',
+      ) as Promise<NotionAuthStartResponse>,
+
+    onSuccess: ({ url }) => {
+      // ここで Notion の認可画面へブラウザ全体遷移する
+      window.location.href = url;
+    },
+
+    onError: (err) => {
+      if (
+        err instanceof HttpError &&
+        err.statusCode === HttpStatus.UNAUTHORIZED
+      ) {
+        // セッション切れ
+        toast.error('ログインし直してください');
+        return;
+      }
+      // ネットワーク不達もしくはサーバエラー
+      toast.error('Notion連携の開始に失敗しました');
+    },
+  });
+
+  return { connect };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.3.2",
         "@nestjs/throttler": "^6.5.0",
+        "@notionhq/client": "^5.22.0",
         "@prisma/client": "^6.19.2",
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
@@ -4059,6 +4060,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@notionhq/client": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-5.22.0.tgz",
+      "integrity": "sha512-lZ3JGBCd6O6MNHWn/58QcUqX1FgmlcODcx/EaUEEpuxLXF5tSi+v29Vzoz8mZ6JgDWDn5pMzzjB69QevYjQQZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@nuxt/opencollective": {

--- a/shared/src/api.ts
+++ b/shared/src/api.ts
@@ -180,6 +180,70 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/integrations/notion/auth": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["NotionOAuthController_startAuth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/integrations/notion/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["NotionOAuthController_callback"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/integrations/notion/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["NotionOAuthController_getStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/integrations/notion": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: operations["NotionOAuthController_deleteIntegration"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -360,6 +424,25 @@ export interface components {
              */
             version: number;
             preview?: components["schemas"]["ReviewPreviewResponse"];
+        };
+        NotionAuthStartResponse: {
+            /**
+             * @description Notion認可画面のURL。フロントはこのURLへブラウザ遷移する。
+             * @example https://api.notion.com/v1/oauth/authorize?client_id=...&response_type=code&owner=user&redirect_uri=...&state=...
+             */
+            url: string;
+        };
+        NotionStatusResponse: {
+            /**
+             * @description Notion連携済みかどうか
+             * @example true
+             */
+            connected: boolean;
+            /**
+             * @description 連携先のNotionワークスペース名（connected=trueのみ）
+             * @example My Workspace
+             */
+            workspaceName?: string;
         };
     };
     responses: never;
@@ -684,6 +767,78 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["CardReviewResponse"];
                 };
+            };
+        };
+    };
+    NotionOAuthController_startAuth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotionAuthStartResponse"];
+                };
+            };
+        };
+    };
+    NotionOAuthController_callback: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    NotionOAuthController_getStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotionStatusResponse"];
+                };
+            };
+        };
+    };
+    NotionOAuthController_deleteIntegration: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };


### PR DESCRIPTION
## 概要
Notion OAuth機能を完成後にSDKの存在を確認したので、SDKでリファクタした。
主な変更点として
- フロントへのリダイレクト方法の変更
- ServiceのFetch部分の置き換え
- Notion連携ボタンとそのフックの作成

フローを実際に動かし、ＤＢに保存されるまで確認できている。
## 詳細
- /authでredirect しない理由
AT は Authorization: Bearer で送る方式のため、ブラウザの直接ナビゲーションではヘッダが付かず JwtAuthGuard を通過できない。fetch で Bearer 付きで取得 →レスポンスの url へフロントが遷移する形にしてある。（既存からのバグ）
- SDKへの移行に伴い、client内部で例外処理をしてくれるのでそれに合わせてエラーハンドリングを合わせた。filterでは例外の種類をcauseによって分類してログの出力を行う。
- 連携ボタンのファイル内にfetchを作らずフックとして切り出し、tanstackqueryで記述した。

次はnotion-api-baseをsdkを用いて作成する。