### PR TITLE
Feat/notion api refresh

### DIFF
--- a/backend/src/integrations/notion/notion-integration.repository.ts
+++ b/backend/src/integrations/notion/notion-integration.repository.ts
@@ -39,6 +39,32 @@ export class NotionIntegrationRepository {
   }
 
   /**
+   * userId に紐づく AT/RT を「平文」で取得する
+   *
+   * 復号はこの層で行い、上位レイヤから CipherService を意識させない方針。
+   * Notion API を叩くときに使う（AT を Authorization に乗せる、RT で refresh する など）。
+   * 未連携の場合は null を返す。
+   */
+  async findDecryptedByUserId(userId: string): Promise<{
+    accessToken: string;
+    refreshToken: string;
+    workspaceId: string;
+    workspaceName: string;
+  } | null> {
+    const integration = await this.prisma.notionIntegration.findUnique({
+      where: { userId },
+    });
+    if (!integration) return null;
+
+    return {
+      accessToken: this.cipher.decrypt(integration.accessTokenEnc),
+      refreshToken: this.cipher.decrypt(integration.refreshTokenEnc),
+      workspaceId: integration.workspaceId,
+      workspaceName: integration.workspaceName,
+    };
+  }
+
+  /**
    * 同一userIdのレコードをあれば上書き、なければ新規作成する
    *
    * Notion設計上、１ユーザは常に最新の１連携情報のみを持つ。

--- a/backend/src/integrations/notion/notion-oauth.service.spec.ts
+++ b/backend/src/integrations/notion/notion-oauth.service.spec.ts
@@ -10,7 +10,7 @@ import {
   beforeAll,
   afterAll,
 } from 'vitest';
-import { BadGatewayException } from '@nestjs/common';
+import { BadGatewayException, UnauthorizedException } from '@nestjs/common';
 import type { NotionIntegration } from '@prisma/client';
 import {
   APIResponseError,
@@ -160,7 +160,7 @@ describe('NotionOAuthService', () => {
     });
 
     // APIResponseError は Notion 側エラー（invalid_grant等）。service は内部用 message で投げ直す
-    it('異常系: APIResponseError → BadGateway (内部用 message / cause 保持)', async () => {
+    it('異常系: APIResponseError → BadGateway (内部用 message)', async () => {
       const apiErr = new APIResponseError({
         code: 'unauthorized' as never,
         status: 401,
@@ -176,13 +176,12 @@ describe('NotionOAuthService', () => {
         {
           constructor: BadGatewayException,
           message: 'Notion連携に失敗しました。',
-          cause: apiErr,
         },
       );
     });
 
     // それ以外（RequestTimeoutError / network 系）は通信用 message で投げ直す
-    it('異常系: RequestTimeoutError → BadGateway (通信用 message / cause 保持)', async () => {
+    it('異常系: RequestTimeoutError → BadGateway (通信用 message)', async () => {
       const timeoutErr = new RequestTimeoutError('request timed out');
       mockOauthToken.mockRejectedValue(timeoutErr);
 
@@ -190,7 +189,6 @@ describe('NotionOAuthService', () => {
         {
           constructor: BadGatewayException,
           message: 'Notionへの接続に失敗しました。',
-          cause: timeoutErr,
         },
       );
     });
@@ -208,6 +206,115 @@ describe('NotionOAuthService', () => {
         await expect(
           service.exchangeCodeForTokens('code'),
         ).rejects.toBeInstanceOf(BadGatewayException);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // refreshTokens
+  // ---------------------------------------------------------------------------
+  describe('refreshTokens', () => {
+    it('正常系: SDKが返したレスポンスから 4項目だけ抽出して返すこと', async () => {
+      // 新しいAT/RTがNotionから返るパターン
+      mockOauthToken.mockResolvedValue(
+        buildOauthResponse({
+          access_token: 'AT-new',
+          refresh_token: 'RT-new',
+          workspace_id: 'ws-1',
+          workspace_name: 'My Workspace',
+          workspace_icon: 'should-be-ignored',
+          bot_id: 'should-be-ignored',
+          token_type: 'bearer',
+        }),
+      );
+
+      const result = await service.refreshTokens('RT-old');
+
+      expect(result).toEqual({
+        access_token: 'AT-new',
+        refresh_token: 'RT-new',
+        workspace_id: 'ws-1',
+        workspace_name: 'My Workspace',
+      });
+    });
+
+    it('呼び出し検証: oauth.token に grant_type=refresh_token と RT/client_id/client_secret が渡されること', async () => {
+      // 認可codeフローとは grant_type と refresh_token 以外が違うので、
+      // 引数が正しく組み立てられているか確認する
+      mockOauthToken.mockResolvedValue(buildOauthResponse({}));
+
+      await service.refreshTokens('RT-zzz');
+
+      expect(mockOauthToken).toHaveBeenCalledTimes(1);
+      expect(mockOauthToken).toHaveBeenCalledWith({
+        grant_type: 'refresh_token',
+        refresh_token: 'RT-zzz',
+        client_id: 'test-client-id',
+        client_secret: 'test-client-secret',
+      });
+    });
+
+    // 4xx は RT 拒否 → ユーザに再連携を促す必要がある
+    it.each<[string, number, string]>([
+      ['400 invalid_grant', 400, 'invalid_grant'],
+      ['401 unauthorized', 401, 'unauthorized'],
+    ])('異常系: %s → UnauthorizedException', async (_label, status, code) => {
+      const apiErr = new APIResponseError({
+        code: code as never,
+        status,
+        message: code,
+        headers: new Headers(),
+        rawBodyText: `{"error":"${code}"}`,
+        additional_data: undefined,
+        request_id: undefined,
+      });
+      mockOauthToken.mockRejectedValue(apiErr);
+
+      await expect(service.refreshTokens('RT')).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+
+    // 5xx は Notion 側障害 → 連携は維持して 502 を返す
+    it('異常系: 5xx → BadGatewayException', async () => {
+      const apiErr = new APIResponseError({
+        code: 'internal_server_error' as never,
+        status: 500,
+        message: 'internal_server_error',
+        headers: new Headers(),
+        rawBodyText: '{}',
+        additional_data: undefined,
+        request_id: undefined,
+      });
+      mockOauthToken.mockRejectedValue(apiErr);
+
+      await expect(service.refreshTokens('RT')).rejects.toBeInstanceOf(
+        BadGatewayException,
+      );
+    });
+
+    // 通信系（RequestTimeoutError）は BadGateway
+    it('異常系: RequestTimeoutError → BadGatewayException', async () => {
+      const timeoutErr = new RequestTimeoutError('request timed out');
+      mockOauthToken.mockRejectedValue(timeoutErr);
+
+      await expect(service.refreshTokens('RT')).rejects.toBeInstanceOf(
+        BadGatewayException,
+      );
+    });
+
+    // OauthTokenResponse は refresh_token / workspace_name が nullable
+    it.each<[string, Partial<OauthTokenResponse>]>([
+      ['refresh_token が null', { refresh_token: null, workspace_name: 'n' }],
+      ['workspace_name が null', { refresh_token: 'r', workspace_name: null }],
+    ])(
+      '異常系: 必須項目欠落 (%s) → BadGatewayException',
+      async (_label, partial) => {
+        mockOauthToken.mockResolvedValue(buildOauthResponse(partial));
+
+        await expect(service.refreshTokens('RT')).rejects.toBeInstanceOf(
+          BadGatewayException,
+        );
       },
     );
   });

--- a/backend/src/integrations/notion/notion-oauth.service.ts
+++ b/backend/src/integrations/notion/notion-oauth.service.ts
@@ -1,4 +1,8 @@
-import { BadGatewayException, Injectable } from '@nestjs/common';
+import {
+  BadGatewayException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { randomBytes } from 'crypto';
 import { NotionIntegrationRepository } from './notion-integration.repository';
 import { getEnv } from '../../common/functions/get-env';
@@ -63,13 +67,9 @@ export class NotionOAuthService {
     } catch (e) {
       // APIResponseError: Notion 側 4xx/5xx ／ それ以外: 通信系
       if (e instanceof APIResponseError) {
-        throw new BadGatewayException('Notion連携に失敗しました。', {
-          cause: e,
-        });
+        throw new BadGatewayException('Notion連携に失敗しました。');
       }
-      throw new BadGatewayException('Notionへの接続に失敗しました。', {
-        cause: e,
-      });
+      throw new BadGatewayException('Notionへの接続に失敗しました。');
     }
     // resがnullableなのでチェック
     if (!response.refresh_token || !response.workspace_name) {
@@ -77,6 +77,53 @@ export class NotionOAuthService {
     }
 
     // NotionTokenResponseを返す
+    return {
+      access_token: response.access_token,
+      refresh_token: response.refresh_token,
+      workspace_id: response.workspace_id,
+      workspace_name: response.workspace_name,
+    };
+  }
+
+  /**
+   * RTを使ってAT/RTを再発行する
+   *
+   * exchangeCodeForTokensがベース
+   * @param refreshToken DB から取り出した平文 RT
+   * @returns 新しい AT/RT を含む NotionTokenResponse
+   */
+  async refreshTokens(refreshToken: string): Promise<NotionTokenResponse> {
+    const notion = new Client();
+
+    let response: OauthTokenResponse;
+    try {
+      response = await notion.oauth.token({
+        grant_type: 'refresh_token', // Notionに「RTからAT/RTを再発行」と知らせる
+        refresh_token: refreshToken,
+        client_id: getEnv('NOTION_CLIENT_ID'),
+        client_secret: getEnv('NOTION_CLIENT_SECRET'),
+      });
+    } catch (e) {
+      // APIResponseError: Notion 側からの 4xx/5xx 応答
+      if (e instanceof APIResponseError) {
+        // 4xx は RT が無効/失効/取消されたケース
+        if (e.status >= 400 && e.status < 500) {
+          throw new UnauthorizedException(
+            'Notion連携が無効になりました。再連携してください。',
+          );
+        }
+        // Notion側の障害（とりあえず502）
+        throw new BadGatewayException('Notion連携の更新に失敗しました。');
+      }
+      // RequestTimeoutError 等の通信系
+      throw new BadGatewayException('Notionへの接続に失敗しました。');
+    }
+
+    // resがnullableなのでチェック
+    if (!response.refresh_token || !response.workspace_name) {
+      throw new BadGatewayException('Notionからのレスポンスが不正です。');
+    }
+
     return {
       access_token: response.access_token,
       refresh_token: response.refresh_token,


### PR DESCRIPTION
## 概要
Refresh機能を作成

## 詳細
- ServiceのRefresh機能に関しては、SDKのメソッド引数のgrant typeをrefresh用に変えただけでexchangeCodeForTokensと何ら変わりない。
- DBから平文でjwtを取得するメソッドに関しては、サービスで復号せずRepository内で完結させている。これによりServiceは暗号化の存在を知らずにjwtを扱える。