### PR TITLE
Feat/notion api base with sdk

### DIFF
--- a/backend/src/integrations/notion/notion-api.client.ts
+++ b/backend/src/integrations/notion/notion-api.client.ts
@@ -1,0 +1,204 @@
+import {
+  BadGatewayException,
+  HttpException,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import {
+  APIErrorCode,
+  APIResponseError,
+  Client,
+  isFullDataSource,
+  isFullPage,
+  iteratePaginatedAPI,
+} from '@notionhq/client';
+import type {
+  DataSourceObjectResponse,
+  PageObjectResponse,
+  QueryDataSourceParameters,
+  QueryDataSourceResponse,
+} from '@notionhq/client/build/src/api-endpoints';
+import { NotionIntegrationRepository } from './notion-integration.repository';
+import { NotionOAuthService } from './notion-oauth.service';
+import { NotionReauthRequiredException } from './notion.exceptions';
+
+/**
+ * Notion API クライアント（SDK ラッパー）
+ *
+ * 本プロジェクトでは、1 database = 1 data_source を前提とし、
+ * 上位レイヤから渡される databaseId は data_source_id として扱う。
+ */
+@Injectable()
+export class NotionApiClient {
+  private readonly logger = new Logger(NotionApiClient.name);
+
+  // 巨大DB対策: 上限到達で打ち切りtruncated=true を返す
+  private static readonly NOTES_LIMIT = 1000;
+  private static readonly PAGE_SIZE = 100;
+
+  constructor(
+    private readonly repository: NotionIntegrationRepository,
+    private readonly oauthService: NotionOAuthService,
+  ) {}
+
+  /** userがshareしたdata_source（DB）一覧を取得する */
+  async searchDatabases(userId: string): Promise<DataSourceObjectResponse[]> {
+    const res = await this.fetchWithRetry(userId, (client) =>
+      // searchの結果には、objectプロパティの要素としてuserやdata_source、pageなどが含まれる
+      // 今回欲しいのはdbなので余計なものを取得しないように制限
+      client.search({
+        filter: { value: 'data_source', property: 'object' },
+        page_size: NotionApiClient.PAGE_SIZE,
+      }),
+    );
+    // res.resultsは型UNIONで複数の型が|で結合されている
+    // そのためres.result.dbみたいにできるように型のフィルタリングしている
+    return res.results.filter(isFullDataSource);
+  }
+
+  /** data_sourceの詳細カラムを取得する */
+  async retrieveDatabase(
+    userId: string,
+    databaseId: string,
+  ): Promise<DataSourceObjectResponse> {
+    const res = await this.fetchWithRetry(userId, (client) =>
+      client.dataSources.retrieve({ data_source_id: databaseId }),
+    );
+    if (!isFullDataSource(res)) {
+      throw new BadGatewayException(
+        'Notionからdatabaseの詳細を取得できませんでした。',
+      );
+    }
+    // 絞り込まず全カラムを返却（ユーザに選択させる）
+    return res;
+  }
+
+  /** data_sourceのpageを全件取得する。NOTES_LIMIT到達で打ち切りtruncated=trueを返す */
+  async queryDatabaseAll(
+    userId: string,
+    databaseId: string,
+  ): Promise<{ pages: PageObjectResponse[]; truncated: boolean }> {
+    const pages: PageObjectResponse[] = [];
+    let truncated = false;
+
+    // iteratePaginatedAPIに渡すfetch関数を準備
+    const queryWithRetry = (
+      args: QueryDataSourceParameters,
+    ): Promise<QueryDataSourceResponse> =>
+      this.fetchWithRetry(userId, (client) => client.dataSources.query(args));
+
+    // iteratePaginatedAPIは(fn, init)を引数として持ち、条件を満たすまで内部でcursorをループする
+    for await (const item of iteratePaginatedAPI(queryWithRetry, {
+      data_source_id: databaseId,
+      page_size: NotionApiClient.PAGE_SIZE,
+    })) {
+      if (isFullPage(item)) {
+        pages.push(item);
+        if (pages.length >= NotionApiClient.NOTES_LIMIT) {
+          truncated = true;
+          break;
+        }
+      }
+    }
+
+    return { pages, truncated };
+  }
+
+  /**
+   * リフレッシュ付きFetch関数 内部でrunWithClientを利用
+   * 401 → refresh → 1回retry / その他 → 502 を集約
+   */
+  private async fetchWithRetry<T>(
+    userId: string,
+    fn: (client: Client) => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await this.runWithClient(userId, fn);
+    } catch (e) {
+      if (
+        // AT無効・期限切れだった場合はリトライ
+        e instanceof APIResponseError &&
+        e.code === APIErrorCode.Unauthorized
+      ) {
+        await this.refreshAccessToken(userId);
+        try {
+          return await this.runWithClient(userId, fn);
+        } catch (e2) {
+          if (
+            // Notion AT/RTが無効な場合
+            e2 instanceof APIResponseError &&
+            e2.code === APIErrorCode.Unauthorized
+          ) {
+            // 再連携が必要なケース。filterで識別してフロントにcodeを返す
+            throw new NotionReauthRequiredException();
+          }
+          // UNAUTHORIZED以外のエラーをハンドル（refresh後）
+          return this.handleNonRetryableError(e2);
+        }
+      }
+      // UNAUTHORIZED以外のエラーをハンドル（初回）
+      return this.handleNonRetryableError(e);
+    }
+  }
+
+  // <T>には各notionクエリの返りデータ型が入る
+  /** DBからATを取り出してClientを組み立て、渡された関数fnを実行する */
+  private async runWithClient<T>(
+    userId: string,
+    fn: (client: Client) => Promise<T>,
+  ): Promise<T> {
+    const tokens = await this.repository.findDecryptedByUserId(userId);
+    if (!tokens) {
+      // 基本的にここにたどり着く前にstatus確認でこの関数は通らない
+      throw new UnauthorizedException('Notion連携が見つかりません。');
+    }
+    return fn(new Client({ auth: tokens.accessToken }));
+  }
+
+  /**
+   * 401以外のエラーを502に正規化
+   * - ネットワークエラーやタイムアウト、Notion障害、その他予期しない例外
+   * - HttpExceptionはそのまま流す
+   */
+  private handleNonRetryableError(e: unknown): never {
+    if (e instanceof HttpException) throw e; // filterに丸投げ
+    if (e instanceof APIResponseError) {
+      throw new BadGatewayException(
+        `Notion API がエラーを返しました（status=${e.status}）。`,
+      );
+    }
+    // 予期しないエラーまたはネットワークエラー
+    this.logger.error('Notion APIへの通信が失敗しました', e);
+    throw new BadGatewayException('Notion APIとの通信に失敗しました。');
+  }
+
+  /** RTを使ってAT/RTを再発行しDBを更新する。RT拒否ならintegrationを削除する */
+  private async refreshAccessToken(userId: string): Promise<void> {
+    const tokens = await this.repository.findDecryptedByUserId(userId);
+    if (!tokens) {
+      // 基本的にここにたどり着く前にstatus確認でこの関数は通らない
+      throw new UnauthorizedException('Notion連携が見つかりません。');
+    }
+    try {
+      const newTokens = await this.oauthService.refreshTokens(
+        tokens.refreshToken,
+      );
+      await this.oauthService.saveNotionResponse(userId, newTokens);
+    } catch (e) {
+      // RTが存在するが拒否された場合はintegrationを消して再連携を要求する
+      if (e instanceof NotionReauthRequiredException) {
+        this.logger.warn(
+          'Notion refreshが拒否されました。integrationを削除します。',
+        );
+        await this.repository.delete(userId);
+        // 再連携要求はNotionApiExceptionFilterで識別され、
+        // body の code フィールドでフロントが再連携モーダルを出す
+        throw new NotionReauthRequiredException(
+          'Notion連携が無効になりました。再連携してください。',
+        );
+      }
+      throw e;
+    }
+  }
+}

--- a/backend/src/integrations/notion/notion-oauth.service.spec.ts
+++ b/backend/src/integrations/notion/notion-oauth.service.spec.ts
@@ -10,7 +10,7 @@ import {
   beforeAll,
   afterAll,
 } from 'vitest';
-import { BadGatewayException, UnauthorizedException } from '@nestjs/common';
+import { BadGatewayException } from '@nestjs/common';
 import type { NotionIntegration } from '@prisma/client';
 import {
   APIResponseError,
@@ -20,6 +20,7 @@ import {
 
 import { NotionOAuthService } from './notion-oauth.service';
 import { NotionIntegrationRepository } from './notion-integration.repository';
+import { NotionReauthRequiredException } from './notion.exceptions';
 
 /**
  * @notionhq/client (Notion 公式 SDK) のモック
@@ -258,22 +259,25 @@ describe('NotionOAuthService', () => {
     it.each<[string, number, string]>([
       ['400 invalid_grant', 400, 'invalid_grant'],
       ['401 unauthorized', 401, 'unauthorized'],
-    ])('異常系: %s → UnauthorizedException', async (_label, status, code) => {
-      const apiErr = new APIResponseError({
-        code: code as never,
-        status,
-        message: code,
-        headers: new Headers(),
-        rawBodyText: `{"error":"${code}"}`,
-        additional_data: undefined,
-        request_id: undefined,
-      });
-      mockOauthToken.mockRejectedValue(apiErr);
+    ])(
+      '異常系: %s → NotionReauthRequiredException',
+      async (_label, status, code) => {
+        const apiErr = new APIResponseError({
+          code: code as never,
+          status,
+          message: code,
+          headers: new Headers(),
+          rawBodyText: `{"error":"${code}"}`,
+          additional_data: undefined,
+          request_id: undefined,
+        });
+        mockOauthToken.mockRejectedValue(apiErr);
 
-      await expect(service.refreshTokens('RT')).rejects.toBeInstanceOf(
-        UnauthorizedException,
-      );
-    });
+        await expect(service.refreshTokens('RT')).rejects.toBeInstanceOf(
+          NotionReauthRequiredException,
+        );
+      },
+    );
 
     // 5xx は Notion 側障害 → 連携は維持して 502 を返す
     it('異常系: 5xx → BadGatewayException', async () => {

--- a/backend/src/integrations/notion/notion-oauth.service.ts
+++ b/backend/src/integrations/notion/notion-oauth.service.ts
@@ -1,8 +1,4 @@
-import {
-  BadGatewayException,
-  Injectable,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { BadGatewayException, Injectable } from '@nestjs/common';
 import { randomBytes } from 'crypto';
 import { NotionIntegrationRepository } from './notion-integration.repository';
 import { getEnv } from '../../common/functions/get-env';
@@ -11,6 +7,7 @@ import {
   APIResponseError,
   type OauthTokenResponse,
 } from '@notionhq/client';
+import { NotionReauthRequiredException } from './notion.exceptions';
 
 /**
  * Notion OAuth tokenエンドポイントのレスポンス（必要項目のみ）
@@ -106,9 +103,10 @@ export class NotionOAuthService {
     } catch (e) {
       // APIResponseError: Notion 側からの 4xx/5xx 応答
       if (e instanceof APIResponseError) {
-        // 4xx は RT が無効/失効/取消されたケース
+        // 4xx は RT が無効/失効/取消されたケース。
+        // 呼び出し元（api.client.refreshAccessToken）で catch されintegrationが削除される
         if (e.status >= 400 && e.status < 500) {
-          throw new UnauthorizedException(
+          throw new NotionReauthRequiredException(
             'Notion連携が無効になりました。再連携してください。',
           );
         }

--- a/backend/src/integrations/notion/notion.exceptions.ts
+++ b/backend/src/integrations/notion/notion.exceptions.ts
@@ -1,0 +1,34 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+/**
+ * Notion 連携専用の例外の基底クラス
+ * これをcatchするのはNotionApiExceptionFilter
+ */
+export abstract class NotionException extends HttpException {
+  constructor(message: string, status: HttpStatus) {
+    super(message, status);
+  }
+}
+
+/**
+ * Notion DB のカラムとしてユーザが選択した column が、
+ * 本文化できない type (checkbox / select / date 等) だった場合の例外。
+ *
+ * 本来フロント側で title / rich_text のみに絞ってから送る想定だが、
+ * フィルタ漏れの保険としてサーバ側でも投げる。
+ */
+export class NotionUnsupportedColumnException extends NotionException {
+  constructor(columnName: string, type: string) {
+    super(
+      `このカラム (${columnName}, type=${type}) は対応外です。title または rich_text のカラムを選択してください。`,
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+}
+
+/** Notion連携が無効になり、ユーザに再連携を要求する必要がある場合の例外 */
+export class NotionReauthRequiredException extends NotionException {
+  constructor(message = 'Notion連携が無効です。再連携してください。') {
+    super(message, HttpStatus.UNAUTHORIZED);
+  }
+}

--- a/backend/src/integrations/notion/notion.mapper.ts
+++ b/backend/src/integrations/notion/notion.mapper.ts
@@ -1,0 +1,145 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type {
+  DataSourceObjectResponse,
+  PageObjectResponse,
+  RichTextItemResponse,
+} from '@notionhq/client/build/src/api-endpoints';
+import type { CreateCardDto } from '../../card/card.service';
+import { NotionUnsupportedColumnException } from './notion.exceptions';
+
+/**
+ * フロントの DB 選択リストで使う最小情報
+ * databaseIdと呼ばれているIDは実体としてはdata_source_id
+ */
+export type NotionDatabaseSummary = {
+  id: string;
+  title: string;
+};
+
+/**
+ * 必要なDBカラム情報
+ *
+ * 現状はフロント側でtypeの絞り込みを行うが、Notionのアップデート遅れで
+ * 古いUIから送られてくる場合や、フロントのフィルタ漏れを考慮してバックでも行う。
+ */
+export type NotionColumnInfo = {
+  name: string; // タイトルにあたる
+  type: string; // notion側のカラム。'rich_text'か'title'に後で絞り込む
+};
+
+/** database 詳細（カラム一覧含む） */
+export type NotionDatabaseDetail = {
+  databaseId: string;
+  databaseTitle: string;
+  columns: NotionColumnInfo[];
+};
+
+/**
+ * Notion pageから抽出した、Card 作成に必要な部分のみの型
+ *
+ * Card service の入力 DTO (`CreateCardDto`) のうち、
+ * Notion から取れるフィールド (name / content) だけを取り出し
+ */
+export type NotionExtractedPage = Pick<CreateCardDto, 'name' | 'content'>;
+
+/**
+ * Notion SDKの各生DTO → CardDTO への変換
+ * card側はnotionを一切知らない
+ */
+@Injectable()
+export class NotionMapper {
+  private readonly logger = new Logger(NotionMapper.name);
+
+  /** rich_text / title の配列を plain_text 連結文字列に変換する */
+  private joinPlainText(items: RichTextItemResponse[] | undefined): string {
+    if (!items || items.length === 0) return '';
+    // Notion はスタイルごとに配列を分割して返すため、表示用に連結する。
+    return items.map((i) => i.plain_text).join('');
+  }
+
+  /** data_source配列をCardDTO に変換する */
+  toDatabases(
+    dataSources: DataSourceObjectResponse[],
+  ): NotionDatabaseSummary[] {
+    return dataSources.map((ds) => ({
+      id: ds.id,
+      title: this.joinPlainText(ds.title), // rich_text を結合
+    }));
+  }
+
+  /**
+   * data_sourceの詳細カラムレスポンスをCardDTOに変換する
+   *
+   * properties は { [カラム名]: { id, name, type, ... } } のマップで返るが、
+   * JSON のキー順は保証されないため、value.name を使って配列化する。
+   * フロント側で type=="title"/"rich_text" の絞り込みを行う想定。
+   */
+  toDatabaseDetail(database: DataSourceObjectResponse): NotionDatabaseDetail {
+    const columns = Object.values(database.properties).map((p) => ({
+      name: p.name,
+      type: p.type,
+    }));
+
+    return {
+      databaseId: database.id,
+      databaseTitle: this.joinPlainText(database.title),
+      columns,
+    };
+  }
+
+  /**
+   * page配列を指定カラム名で。NotionExtractedPageに変換する
+   *
+   * タイトルと内容を特定後に変換をかける。
+   * 返却値はそのままCreateCardDtoには流せない（deckId/userId/type
+   * が不足）ため、service側で残りのフィールドを合成すること。
+   */
+  toNotes(
+    pages: PageObjectResponse[],
+    columnName: string,
+  ): NotionExtractedPage[] {
+    return pages.map((page) => {
+      // title型プロパティを探す（typeで特定）
+      const titleProp = Object.values(page.properties).find(
+        (p) => p.type === 'title',
+      );
+      const name =
+        titleProp && titleProp.type === 'title'
+          ? this.joinPlainText(titleProp.title)
+          : '';
+
+      // 内容をユーザが指定したプロパティ名で取り出す
+      const target = page.properties[columnName];
+      const content = this.propertyToString(target, columnName, page.id);
+
+      return { name, content };
+    });
+  }
+
+  /** プロパティ値を文字列化するヘルパ */
+  private propertyToString(
+    prop: PageObjectResponse['properties'][string] | undefined,
+    columnName: string,
+    pageId: string,
+  ): string {
+    // DBのカラムがpageに無いケース（後から削除された等）
+    if (!prop) {
+      this.logger.warn(
+        `page ${pageId} に columnName=${columnName} のプロパティが見つかりません。`,
+      );
+      return '';
+    }
+    if (prop.type === 'title') {
+      return this.joinPlainText(prop.title);
+    }
+    if (prop.type === 'rich_text') {
+      return this.joinPlainText(prop.rich_text);
+    }
+    // 対応しているのは title / rich_text のみ。それ以外（checkbox / select / date 等）は
+    // 文字列化できないため、ここでフロントに「対応外」を伝える。
+    this.logger.warn(
+      `page ${pageId} の columnName=${columnName} は type=${prop.type} のため対応外です。`,
+    );
+    throw new NotionUnsupportedColumnException(columnName, prop.type);
+  }
+}

--- a/backend/src/integrations/notion/notion.module.ts
+++ b/backend/src/integrations/notion/notion.module.ts
@@ -2,14 +2,21 @@ import { Module } from '@nestjs/common';
 import { AuthModule } from '../../auth/auth.module';
 import { EncryptionModule } from '../../common/encryption/encryption.module';
 import { PrismaModule } from '../../prisma/prisma.module';
+import { NotionApiClient } from './notion-api.client';
 import { NotionIntegrationRepository } from './notion-integration.repository';
+import { NotionMapper } from './notion.mapper';
 import { NotionOAuthController } from './notion-oauth.controller';
 import { NotionOAuthService } from './notion-oauth.service';
 
 @Module({
   imports: [PrismaModule, EncryptionModule, AuthModule],
   controllers: [NotionOAuthController],
-  providers: [NotionOAuthService, NotionIntegrationRepository],
+  providers: [
+    NotionOAuthService,
+    NotionIntegrationRepository,
+    NotionApiClient,
+    NotionMapper,
+  ],
   exports: [NotionOAuthService, NotionIntegrationRepository],
 })
 export class NotionModule {}


### PR DESCRIPTION
## 概要
- NotionとのAPI接続を行うNotionAPIClientを作成。
notionのデータ取得サービスはこのclientを呼び出してNotionから情報取得を行う。
- NotionとCardへの変換Mapperを作成。
中間DTOは挟まずCardに変換

## 概要
### Notion-api.Client
今回のNotion連携機能で必要な呼び出しは３つある。
- DB一覧取得 searchDatabase
- 特定DBのカラム詳細を取得 retrieveDatabase
- 特定DBの全pageを取得 queryDatabaseAll
これらの取得メソッドは一つのfetchラッパ(FetchWithRetry)を基盤として構築し利用する方針で実装する。
FetchWithRetryはrunWithClientの結果を例外処理し、TokenをRefreshすることまで含めたラッパーである。

### NotionMapper
Notion連携機能の書く呼び出しの返り値をCard型に変換するMapperを作成した。
Cardの作成にはname, contentしか必要ない。（今回はQUIZ対応なし）その他のdeckIdやuserIdはserviceで付与する形をとる。
またmapperで発生した例外はNotion-data-controllerに別途特殊filterを作成し、例外を吸収する。

次に各ファイルのテストを行う。