### PR TITLE
test: MapperとAPIの単体テストを作成

### DIFF
--- a/backend/src/integrations/notion/notion-api.client.spec.ts
+++ b/backend/src/integrations/notion/notion-api.client.spec.ts
@@ -1,0 +1,322 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Test, TestingModule } from '@nestjs/testing';
+import { mockDeep, type DeepMockProxy } from 'vitest-mock-extended';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { BadGatewayException, UnauthorizedException } from '@nestjs/common';
+import { APIResponseError, RequestTimeoutError } from '@notionhq/client';
+import type {
+  DataSourceObjectResponse,
+  PageObjectResponse,
+  QueryDataSourceResponse,
+  SearchResponse,
+} from '@notionhq/client/build/src/api-endpoints';
+
+import { NotionApiClient } from './notion-api.client';
+import { NotionIntegrationRepository } from './notion-integration.repository';
+import { NotionOAuthService } from './notion-oauth.service';
+import { NotionReauthRequiredException } from './notion.exceptions';
+
+/**
+ * @notionhq/client のモック
+ *  - Client は class として差し替え
+ *  - APIResponseError / isFullDataSource / isFullPage / iteratePaginatedAPI は実物を残す
+ *    （instanceof 判定や Iterator 動作は本物が必要だから）
+ */
+const { mockSearch, mockDataSourcesRetrieve, mockDataSourcesQuery } =
+  vi.hoisted(() => ({
+    mockSearch: vi.fn(),
+    mockDataSourcesRetrieve: vi.fn(),
+    mockDataSourcesQuery: vi.fn(),
+  }));
+
+vi.mock('@notionhq/client', async () => {
+  const actual =
+    await vi.importActual<typeof import('@notionhq/client')>(
+      '@notionhq/client',
+    );
+  return {
+    ...actual,
+    Client: class {
+      search = mockSearch;
+      dataSources = {
+        retrieve: mockDataSourcesRetrieve,
+        query: mockDataSourcesQuery,
+      };
+    },
+  };
+});
+
+/**
+ * isFullDataSource を通過する最小限の DataSourceObjectResponse を作る
+ * 必要な識別フィールドだけ埋め、残りは Partial キャストで省略する仕様
+ */
+const buildDataSource = (
+  id: string,
+  overrides: Partial<DataSourceObjectResponse> = {},
+): DataSourceObjectResponse =>
+  ({
+    object: 'data_source',
+    id,
+    title: [],
+    description: [],
+    properties: {},
+    icon: null,
+    cover: null,
+    url: `https://notion.so/${id}`,
+    public_url: null,
+    is_inline: false,
+    in_trash: false,
+    archived: false,
+    created_time: '2026-01-01T00:00:00.000Z',
+    last_edited_time: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }) as DataSourceObjectResponse;
+
+/** isFullPage を通過する最小限の PageObjectResponse を作る */
+const buildPage = (id: string): PageObjectResponse =>
+  ({
+    object: 'page',
+    id,
+    created_time: '2026-01-01T00:00:00.000Z',
+    last_edited_time: '2026-01-01T00:00:00.000Z',
+    created_by: { object: 'user', id: 'u' },
+    last_edited_by: { object: 'user', id: 'u' },
+    cover: null,
+    icon: null,
+    parent: { type: 'data_source_id', data_source_id: 'ds-1' },
+    archived: false,
+    in_trash: false,
+    properties: {},
+    url: `https://notion.so/${id}`,
+    public_url: null,
+  }) as PageObjectResponse;
+
+/** search レスポンスを作る */
+const buildSearchResponse = (
+  results: SearchResponse['results'],
+): SearchResponse => ({
+  type: 'page_or_data_source',
+  page_or_data_source: {},
+  object: 'list',
+  next_cursor: null,
+  has_more: false,
+  results,
+});
+
+/** query レスポンスを作る */
+const buildQueryResponse = (
+  results: QueryDataSourceResponse['results'],
+  has_more = false,
+  next_cursor: string | null = null,
+): QueryDataSourceResponse => ({
+  type: 'page_or_data_source',
+  page_or_data_source: {},
+  object: 'list',
+  next_cursor,
+  has_more,
+  results,
+});
+
+/** 401 APIResponseError を作る */
+const buildUnauthorizedError = () =>
+  new APIResponseError({
+    code: 'unauthorized' as never,
+    status: 401,
+    message: 'unauthorized',
+    headers: new Headers(),
+    rawBodyText: '{}',
+    additional_data: undefined,
+    request_id: undefined,
+  });
+
+/** 5xx APIResponseError を作る */
+const buildServerError = () =>
+  new APIResponseError({
+    code: 'internal_server_error' as never,
+    status: 500,
+    message: 'internal_server_error',
+    headers: new Headers(),
+    rawBodyText: '{}',
+    additional_data: undefined,
+    request_id: undefined,
+  });
+
+// NotionApiClient
+describe('NotionApiClient', () => {
+  let client: NotionApiClient;
+  let repoMock: DeepMockProxy<NotionIntegrationRepository>;
+  let oauthMock: DeepMockProxy<NotionOAuthService>;
+
+  beforeEach(async () => {
+    repoMock = mockDeep<NotionIntegrationRepository>();
+    oauthMock = mockDeep<NotionOAuthService>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotionApiClient,
+        { provide: NotionIntegrationRepository, useValue: repoMock },
+        { provide: NotionOAuthService, useValue: oauthMock },
+      ],
+    }).compile();
+
+    client = module.get<NotionApiClient>(NotionApiClient);
+
+    // hoisted した Client モックは全テスト共有なので毎回リセットする
+    mockSearch.mockReset();
+    mockDataSourcesRetrieve.mockReset();
+    mockDataSourcesQuery.mockReset();
+
+    // デフォルト: AT/RT が取れる状態にしておく（個別テストで上書き可）
+    repoMock.findDecryptedByUserId.mockResolvedValue({
+      accessToken: 'AT',
+      refreshToken: 'RT',
+      workspaceId: 'ws',
+      workspaceName: 'name',
+    });
+  });
+
+  /** queryDatabaseAll（ページネーション・打ち切りロジックは固有ロジックなので単体で担保） */
+  describe('queryDatabaseAll', () => {
+    it('正常系: 単発ページ (has_more=false) なら 1 回呼んで終わる', async () => {
+      const pages = [buildPage('p1'), buildPage('p2')];
+      mockDataSourcesQuery.mockResolvedValue(buildQueryResponse(pages));
+
+      const result = await client.queryDatabaseAll('user-1', 'ds-1');
+
+      expect(result.pages.map((p) => p.id)).toEqual(['p1', 'p2']);
+      expect(result.truncated).toBe(false);
+      expect(mockDataSourcesQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it('正常系: has_more=true なら next_cursor で 2 回目を呼んで結合する', async () => {
+      // 1ページ目: 100件 + has_more=true + next_cursor='c1'
+      const firstPage = Array.from({ length: 100 }, (_, i) =>
+        buildPage(`p${i}`),
+      );
+      // 2ページ目: 残り 50件 + has_more=false
+      const secondPage = Array.from({ length: 50 }, (_, i) =>
+        buildPage(`p${100 + i}`),
+      );
+      mockDataSourcesQuery
+        .mockResolvedValueOnce(buildQueryResponse(firstPage, true, 'c1'))
+        .mockResolvedValueOnce(buildQueryResponse(secondPage));
+
+      const result = await client.queryDatabaseAll('user-1', 'ds-1');
+
+      expect(result.pages).toHaveLength(150);
+      expect(result.truncated).toBe(false);
+      expect(mockDataSourcesQuery).toHaveBeenCalledTimes(2);
+
+      // 2 回目の呼び出しに start_cursor='c1' が渡っているか
+      const secondCall = mockDataSourcesQuery.mock.calls[1][0] as {
+        start_cursor?: string;
+      };
+      expect(secondCall.start_cursor).toBe('c1');
+    });
+
+    it('正常系: 1000件で打ち切り、truncated=true を返す', async () => {
+      // 1〜10ページ目: 各100件、最後の page で has_more=true をセット
+      for (let i = 0; i < 10; i++) {
+        const pageItems = Array.from({ length: 100 }, (_, j) =>
+          buildPage(`p${i * 100 + j}`),
+        );
+        // 10ページ目（i=9）でも has_more=true にして、打ち切りトリガーを確認
+        mockDataSourcesQuery.mockResolvedValueOnce(
+          buildQueryResponse(pageItems, true, `c${i + 1}`),
+        );
+      }
+
+      const result = await client.queryDatabaseAll('user-1', 'ds-1');
+
+      expect(result.pages).toHaveLength(1000);
+      expect(result.truncated).toBe(true);
+    });
+
+    // 「full page でない item（partial）が isFullPage で除外される」は SDK の型ガード
+    // 挙動そのものなので、結合テストで担保する。
+  });
+
+  // withRetry
+  describe('withRetry: 401 → refresh → retry', () => {
+    it('正常系: 401 → refresh 成功 → 2回目で成功', async () => {
+      // 初回 401 → 2回目で成功させる
+      mockSearch
+        .mockRejectedValueOnce(buildUnauthorizedError())
+        .mockResolvedValueOnce(buildSearchResponse([buildDataSource('ds-1')]));
+
+      // refresh 成功
+      oauthMock.refreshTokens.mockResolvedValue({
+        access_token: 'AT-new',
+        refresh_token: 'RT-new',
+        workspace_id: 'ws',
+        workspace_name: 'name',
+      });
+
+      const result = await client.searchDatabases('user-1');
+
+      expect(result).toHaveLength(1);
+      expect(oauthMock.refreshTokens).toHaveBeenCalledWith('RT');
+      expect(oauthMock.saveNotionResponse).toHaveBeenCalledTimes(1);
+      expect(mockSearch).toHaveBeenCalledTimes(2);
+    });
+
+    it('異常系: refresh 後も 401 → NotionReauthRequiredException', async () => {
+      mockSearch
+        .mockRejectedValueOnce(buildUnauthorizedError())
+        .mockRejectedValueOnce(buildUnauthorizedError());
+
+      oauthMock.refreshTokens.mockResolvedValue({
+        access_token: 'AT-new',
+        refresh_token: 'RT-new',
+        workspace_id: 'ws',
+        workspace_name: 'name',
+      });
+
+      await expect(client.searchDatabases('user-1')).rejects.toBeInstanceOf(
+        NotionReauthRequiredException,
+      );
+    });
+
+    it('異常系: refresh 自体が RT 拒否 → repository.delete + NotionReauthRequiredException', async () => {
+      mockSearch.mockRejectedValueOnce(buildUnauthorizedError());
+
+      // refresh は NotionReauthRequiredException を投げる (RT 拒否)
+      oauthMock.refreshTokens.mockRejectedValue(
+        new NotionReauthRequiredException('RT rejected'),
+      );
+
+      await expect(client.searchDatabases('user-1')).rejects.toBeInstanceOf(
+        NotionReauthRequiredException,
+      );
+
+      // integration が削除されたこと
+      expect(repoMock.delete).toHaveBeenCalledWith('user-1');
+    });
+  });
+
+  describe('withRetry: その他のエラー', () => {
+    it('異常系: 5xx → BadGatewayException', async () => {
+      mockSearch.mockRejectedValue(buildServerError());
+
+      await expect(client.searchDatabases('user-1')).rejects.toBeInstanceOf(
+        BadGatewayException,
+      );
+    });
+
+    it('異常系: RequestTimeoutError → BadGatewayException', async () => {
+      mockSearch.mockRejectedValue(new RequestTimeoutError('timeout'));
+
+      await expect(client.searchDatabases('user-1')).rejects.toBeInstanceOf(
+        BadGatewayException,
+      );
+    });
+
+    it('異常系: integration が見つからない → UnauthorizedException', async () => {
+      repoMock.findDecryptedByUserId.mockResolvedValue(null);
+
+      await expect(client.searchDatabases('user-1')).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+  });
+});

--- a/backend/src/integrations/notion/notion.mapper.spec.ts
+++ b/backend/src/integrations/notion/notion.mapper.spec.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type {
+  DataSourceObjectResponse,
+  PageObjectResponse,
+  RichTextItemResponse,
+} from '@notionhq/client/build/src/api-endpoints';
+
+import { NotionMapper } from './notion.mapper';
+import { NotionUnsupportedColumnException } from './notion.exceptions';
+
+/** テスト用ヘルパ */
+
+/** RichTextItemResponse を最小限の plain_text だけで作る */
+const rt = (text: string): RichTextItemResponse =>
+  ({ plain_text: text }) as RichTextItemResponse;
+
+/**
+ * DataSourceObjectResponse をテスト用に作る。
+ * mapper は型ガードを通さず id / title / properties しか読まないため、
+ * その3項目だけ埋めて残りは cast で省略する。
+ */
+const buildDataSource = (
+  overrides: Partial<DataSourceObjectResponse>,
+): DataSourceObjectResponse =>
+  ({
+    id: 'ds-1',
+    title: [],
+    properties: {},
+    ...overrides,
+  }) as DataSourceObjectResponse;
+
+/**
+ * PageObjectResponse をテスト用に作る。
+ * mapper は id / properties しか読まないため、その2項目だけ埋める。
+ * properties は呼び出し側で具体的な型を入れたいので Record<string, unknown> を受ける。
+ */
+const buildPage = (
+  id: string,
+  properties: Record<string, unknown>,
+): PageObjectResponse =>
+  ({
+    id,
+    properties,
+  }) as PageObjectResponse;
+
+/** NotionMapper */
+describe('NotionMapper', () => {
+  let mapper: NotionMapper;
+
+  beforeEach(() => {
+    mapper = new NotionMapper();
+  });
+
+  /** toDatabases */
+  describe('toDatabases', () => {
+    it('正常系: title を plain_text 連結する', () => {
+      const ds = buildDataSource({
+        id: 'ds-1',
+        title: [rt('Hello'), rt(' '), rt('World')],
+      });
+
+      const result = mapper.toDatabases([ds]);
+
+      expect(result).toEqual([{ id: 'ds-1', title: 'Hello World' }]);
+    });
+
+    it('正常系: 空 title は空文字になる', () => {
+      const ds = buildDataSource({ id: 'ds-4', title: [] });
+      expect(mapper.toDatabases([ds])[0].title).toBe('');
+    });
+  });
+
+  /** toDatabaseDetail */
+  describe('toDatabaseDetail', () => {
+    it('正常系: properties マップをカラム配列に変換する', () => {
+      const ds = buildDataSource({
+        id: 'ds-1',
+        title: [rt('Books')],
+        // propertiesは型が巨大な union のため、テストでは as never で無理やり代入
+        properties: {
+          Name: { id: 'a', name: 'Name', type: 'title' },
+          Body: { id: 'b', name: 'Body', type: 'rich_text' },
+          Done: { id: 'c', name: 'Done', type: 'checkbox' },
+        } as never,
+      });
+
+      const result = mapper.toDatabaseDetail(ds);
+
+      expect(result.databaseId).toBe('ds-1');
+      expect(result.databaseTitle).toBe('Books');
+      // 順序は JSON のキー順なので順序検証は控えめにする
+      expect(result.columns).toEqual(
+        expect.arrayContaining([
+          { name: 'Name', type: 'title' },
+          { name: 'Body', type: 'rich_text' },
+          { name: 'Done', type: 'checkbox' },
+        ]),
+      );
+      expect(result.columns).toHaveLength(3);
+    });
+
+    it('正常系: properties が空でも空配列を返す', () => {
+      const ds = buildDataSource({ id: 'ds-empty', properties: {} });
+      const result = mapper.toDatabaseDetail(ds);
+      expect(result.columns).toEqual([]);
+    });
+  });
+
+  /** toNotes */
+  describe('toNotes', () => {
+    it('正常系: title 型プロパティを name に、columnName を content に変換', () => {
+      const pages = [
+        buildPage('p1', {
+          Name: { id: 't', type: 'title', title: [rt('Title1')] },
+          Body: { id: 'b', type: 'rich_text', rich_text: [rt('Body1')] },
+        }),
+        buildPage('p2', {
+          Name: { id: 't', type: 'title', title: [rt('Title2')] },
+          Body: { id: 'b', type: 'rich_text', rich_text: [rt('Body2')] },
+        }),
+      ];
+
+      const result = mapper.toNotes(pages, 'Body');
+
+      expect(result).toEqual([
+        { name: 'Title1', content: 'Body1' },
+        { name: 'Title2', content: 'Body2' },
+      ]);
+    });
+
+    it('正常系: title 型を本文として指定したら title 値が content に入る', () => {
+      const pages = [
+        buildPage('p1', {
+          Name: { id: 't', type: 'title', title: [rt('Both')] },
+        }),
+      ];
+
+      const result = mapper.toNotes(pages, 'Name');
+
+      expect(result).toEqual([{ name: 'Both', content: 'Both' }]);
+    });
+
+    it('正常系: 指定カラムが存在しない page は content=空文字', () => {
+      const pages = [
+        buildPage('p1', {
+          Name: { id: 't', type: 'title', title: [rt('OnlyTitle')] },
+        }),
+      ];
+
+      const result = mapper.toNotes(pages, 'MissingColumn');
+
+      expect(result).toEqual([{ name: 'OnlyTitle', content: '' }]);
+    });
+
+    it('異常系: 未対応型 (例: checkbox) は NotionUnsupportedColumnException を投げる', () => {
+      // title / rich_text 以外のカラムを選んだ場合、mapper は文字列化できないため
+      // Notion 用の独自例外を投げてフロントに「対応外」を伝える
+      const pages = [
+        buildPage('p1', {
+          Name: { id: 't', type: 'title', title: [rt('T')] },
+          Done: { id: 'c', type: 'checkbox', checkbox: true },
+        }),
+      ];
+
+      expect(() => mapper.toNotes(pages, 'Done')).toThrow(
+        NotionUnsupportedColumnException,
+      );
+    });
+
+    it('正常系: title 型プロパティが無い page は name=空文字', () => {
+      // 実運用では起きないが、partial や破損データへの保険
+      const pages = [
+        buildPage('p1', {
+          Body: { id: 'b', type: 'rich_text', rich_text: [rt('OnlyBody')] },
+        }),
+      ];
+
+      const result = mapper.toNotes(pages, 'Body');
+
+      expect(result).toEqual([{ name: '', content: 'OnlyBody' }]);
+    });
+
+    it('正常系: スタイル分割された rich_text を結合する', () => {
+      const pages = [
+        buildPage('p1', {
+          Name: { id: 't', type: 'title', title: [rt('Hello, ')] },
+          Body: {
+            id: 'b',
+            type: 'rich_text',
+            // 太字部分とリンク部分でセグメント分割されたパターン
+            rich_text: [rt('start '), rt('middle'), rt(' end')],
+          },
+        }),
+      ];
+
+      const result = mapper.toNotes(pages, 'Body');
+
+      expect(result[0].content).toBe('start middle end');
+    });
+  });
+});


### PR DESCRIPTION
## 概要
APIClientとNotionMapperの単体テストを実施した。

## 詳細
全てを網羅的にやるとコスパが悪いので、以下のように絞った。
### NotionAPIClient
searchDatabases, RetrieveDatabaseはFetchWithRetryを使った薄いラッパーなので実質FetchWithRetryの試験をしていることになる。よってそれらは単体は行わずdata-importで結合を通して試験する。対して、1000件打ち切りやretryの例外処理分岐などのロジックは単体試験で確認する必要がある。結合でやるとコストが大きすぎる。

### NotionMapper
Mapperに関しては単純に単体のロジックなので特に言うことはない。

--- 
ちなみに本プロジェクトにおけるテスト戦略としては、限られた時間でまずは動くことを重視しているのでテストの比重は小さくしている。
そのため実際に手でテストコードを書くことは難しく、詳細はAIに任せている。「単体・結合のどちらが適切か」、「仕様に対してどんなテストが必要か」、「コードが大体何をしているか」、「そもそもテストの必要があるのか」などの概要は把握しており、詳細なコード理解はしていないことが多い。
テストコードはプログラムの欠陥に対する予防策として、プログラムの品質を担保するうえで重要な要因だが、セキュリティーの穴による個人情報の漏洩などはテストコードの詳細によって直接的に発生しない。何をどう試験しているかさえ理解できれば詳細の理解は実際のコードと比べれば重要度は比較的低いと考えた。
ただし、重要であることは変わりないため、今後の学習で詳細の理解を進めていきたい。