### PR TITLE
Feat/notion data import

### DIFF
--- a/backend/src/card/card.module.ts
+++ b/backend/src/card/card.module.ts
@@ -17,6 +17,6 @@ import { ReviewService } from './review.service';
       useClass: CardRepository, // 実装
     },
   ],
-  exports: [CardService],
+  exports: [CardService, 'ICardRepository'],
 })
 export class CardModule {}

--- a/backend/src/card/card.repository.interface.ts
+++ b/backend/src/card/card.repository.interface.ts
@@ -21,6 +21,11 @@ export interface ICardRepository {
     version: number,
     data: Prisma.CardUncheckedUpdateInput,
   ): Promise<Card | null>;
+  createManyNote(input: {
+    userId: string;
+    deckId: bigint;
+    rawNotes: { name: string; content: string | null }[];
+  }): Promise<number>;
 }
 
 // DI用のトークン

--- a/backend/src/card/card.repository.ts
+++ b/backend/src/card/card.repository.ts
@@ -2,7 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { ICardRepository } from './card.repository.interface';
 import { Card, Prisma } from '@prisma/client';
-import { CardNotFoundException } from '../common/exceptions/domain.exceptions';
+import {
+  CardNotFoundException,
+  DeckNotFoundException,
+} from '../common/exceptions/domain.exceptions';
+import { CardType } from '@memo-anki/shared';
 
 // userIdをwhereに含めることで一貫してrepositoryでの認可の強化を推進している。
 @Injectable()
@@ -27,6 +31,43 @@ export class CardRepository implements ICardRepository {
   async findCards(userId: string): Promise<Card[]> {
     return await this.prismaService.card.findMany({
       where: { deck: { userId } },
+    });
+  }
+
+  /**
+   * 複数Noteカードを一括 INSERT する
+   *
+   * - チャンク分割は小規模では過剰と判断し使用しない。
+   * - Notionからのデータ取得はTXにより中途半端でインポートされるのを防ぐ
+   * - 純粋なカードのロジックとして実装。（Notion等の外部サービスは知らない）
+   * @returns 作成されたカード総数
+   */
+  async createManyNote(input: {
+    userId: string;
+    deckId: bigint;
+    rawNotes: { name: string; content: string | null }[];
+  }): Promise<number> {
+    return this.prismaService.$transaction(async (tx) => {
+      // 指定されたdeckがuserのものか確認
+      // tx内であり、DeckServiceはtxを受け付けない仕様のため直呼びしている。
+      const deck = await tx.deck.findFirst({
+        where: { id: input.deckId, userId: input.userId },
+        select: { id: true }, // idだけ取得
+      });
+      if (!deck) {
+        throw new DeckNotFoundException(String(input.deckId));
+      }
+
+      // 受け取ったデータをCardsにする。
+      const data = input.rawNotes.map((rawNote) => ({
+        deckId: input.deckId,
+        name: rawNote.name,
+        type: CardType.NOTE,
+        content: rawNote.content,
+      }));
+      // 一括INSERT
+      const result = await tx.card.createMany({ data });
+      return result.count;
     });
   }
 

--- a/backend/src/integrations/notion/dto/notion-column.response.ts
+++ b/backend/src/integrations/notion/dto/notion-column.response.ts
@@ -1,0 +1,50 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { NotionDatabaseDetail } from '../notion.mapper';
+
+/**
+ * 必要部分だけ取り出したNotion DBのカラム情報
+ */
+export class NotionColumnItem {
+  /** DBのカラム名 */
+  @ApiProperty({ example: 'Body', description: 'カラム名' })
+  name: string;
+
+  /** Notionのプロパティ型 */
+  @ApiProperty({
+    example: 'rich_text',
+    description: 'Notion プロパティ型 (title / rich_text / select 等)',
+  })
+  type: string;
+
+  constructor(name: string, type: string) {
+    this.name = name;
+    this.type = type;
+  }
+}
+
+/**
+ * Notion DB のカラム一覧レスポンス
+ *
+ * フロントは type=='title'/'rich_text' のみフィルタしてユーザに見せる想定。
+ */
+export class NotionColumnListResponse {
+  @ApiProperty({
+    example: 'e9b3f1c2-...',
+    description: 'Notion DB の ID',
+  })
+  databaseId: string;
+
+  @ApiProperty({ example: 'Books', description: 'DB の表示名' })
+  databaseTitle: string;
+
+  @ApiProperty({ type: [NotionColumnItem], description: '全カラム' })
+  columns: NotionColumnItem[];
+
+  constructor(detail: NotionDatabaseDetail) {
+    this.databaseId = detail.databaseId;
+    this.databaseTitle = detail.databaseTitle;
+    this.columns = detail.columns.map(
+      (c) => new NotionColumnItem(c.name, c.type),
+    );
+  }
+}

--- a/backend/src/integrations/notion/dto/notion-database.response.ts
+++ b/backend/src/integrations/notion/dto/notion-database.response.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { NotionDatabaseSummary } from '../notion.mapper';
+
+/**
+ * Notion連携で選択されたdatabaseを1件返却
+ */
+export class NotionDatabaseItem {
+  /** データソースID */
+  @ApiProperty({
+    example: 'e9b3f1c2-...-...',
+    description: 'Notion DB の ID',
+  })
+  id: string;
+
+  /** DBの名前 */
+  @ApiProperty({ example: 'Books', description: 'DB の表示名' })
+  title: string;
+
+  constructor(item: NotionDatabaseSummary) {
+    this.id = item.id;
+    this.title = item.title;
+  }
+}
+
+/**
+ * Notion DB 一覧のレスポンス
+ */
+export class NotionDatabaseListResponse {
+  @ApiProperty({
+    type: [NotionDatabaseItem],
+    description: 'user が Notion 側で share した database 一覧',
+  })
+  databases: NotionDatabaseItem[];
+
+  constructor(items: NotionDatabaseSummary[]) {
+    this.databases = items.map((item) => new NotionDatabaseItem(item));
+  }
+}

--- a/backend/src/integrations/notion/dto/notion-import.request.ts
+++ b/backend/src/integrations/notion/dto/notion-import.request.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumberString, Length } from 'class-validator';
+import { NotBlank } from '../../../common/decorators/not-blank.decorator';
+
+/**
+ * Notion DB のインポート実行 リクエスト body
+ *
+ *  - deckId : import 先 deck
+ *  - columnName : Notion DBのどのカラム値をCardのcontentにするか
+ */
+export class NotionImportRequest {
+  @ApiProperty({
+    example: '1',
+    description: 'bigint ID of the destination deck',
+  })
+  @NotBlank()
+  @IsNumberString()
+  @Length(1, 19)
+  deckId: string;
+
+  @ApiProperty({
+    example: 'Body',
+    maxLength: 200,
+    description: 'Notion DB の本文として取り込むカラム名',
+  })
+  @NotBlank()
+  @Length(1, 200)
+  columnName: string;
+}

--- a/backend/src/integrations/notion/dto/notion-import.response.ts
+++ b/backend/src/integrations/notion/dto/notion-import.response.ts
@@ -1,0 +1,24 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Notion DB インポート完了レスポンス
+ *
+ *  - count     : 作成されたカード数
+ *  - truncated : Notion 側 1000 件上限で打ち切ったならTrue
+ */
+export class NotionImportResponse {
+  @ApiProperty({ example: 123, description: '作成されたカード数' })
+  count: number;
+
+  @ApiPropertyOptional({
+    example: false,
+    description: 'true なら 1000 件上限で打ち切ったことを示す',
+  })
+  truncated?: boolean;
+
+  constructor(count: number, truncated: boolean) {
+    this.count = count;
+    // false のときは省略
+    this.truncated = truncated || undefined;
+  }
+}

--- a/backend/src/integrations/notion/notion-api.exception.filter.ts
+++ b/backend/src/integrations/notion/notion-api.exception.filter.ts
@@ -1,0 +1,33 @@
+import { ArgumentsHost, Catch, ExceptionFilter, Logger } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { NotionReauthRequiredException } from './notion.exceptions';
+
+/**
+ * Notion APIエンドポイント用の例外フィルタ
+ *
+ * フロント側で JWT 期限切れ等の通常 401 と区別する必要があるため、
+ *  再連携要求にだけ専用 `code` を載せて返す。
+ */
+@Catch(NotionReauthRequiredException)
+export class NotionApiExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(NotionApiExceptionFilter.name);
+
+  catch(exception: NotionReauthRequiredException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const res = ctx.getResponse<Response>();
+    const req = ctx.getRequest<Request>();
+    const status = exception.getStatus();
+
+    // ユーザ操作起因の業務エラー想定。スタックトレースまでは要らないので warn。
+    this.logger.warn(`${exception.message} - Path: ${req.url}`);
+
+    // 再連携要求: フロントが他の 401 と区別できるよう専用 code を載せる
+    return res.status(status).json({
+      statusCode: status,
+      code: 'NOTION_REAUTH_REQUIRED',
+      message: exception.message,
+      timestamp: new Date().toISOString(),
+      path: req.url,
+    });
+  }
+}

--- a/backend/src/integrations/notion/notion-data.controller.ts
+++ b/backend/src/integrations/notion/notion-data.controller.ts
@@ -1,0 +1,82 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  UseFilters,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiParam, ApiResponse } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/jwt.guard';
+import { GetUserId } from '../../common/decorators/get-userid.decorator';
+import { NotionDataService } from './notion-data.service';
+import { NotionDatabaseListResponse } from './dto/notion-database.response';
+import { NotionColumnListResponse } from './dto/notion-column.response';
+import { NotionImportRequest } from './dto/notion-import.request';
+import { NotionImportResponse } from './dto/notion-import.response';
+import { NotionApiExceptionFilter } from './notion-api.exception.filter';
+
+/**
+ * Notion連携データ取得エンドポイント
+ * - DB一覧取得
+ * - カラム一覧取得
+ * - 全件Card変換
+ * URLパラメータのidはdata_source_id
+ */
+@UseFilters(NotionApiExceptionFilter)
+@Controller('/integrations/notion/databases')
+export class NotionDataController {
+  constructor(private readonly dataService: NotionDataService) {}
+
+  /** データベース一覧取得 */
+  @UseGuards(JwtAuthGuard)
+  @Get()
+  @ApiResponse({ status: 200, type: NotionDatabaseListResponse })
+  async getDatabases(
+    @GetUserId() userId: string,
+  ): Promise<NotionDatabaseListResponse> {
+    const databases = await this.dataService.getDatabases(userId);
+    return new NotionDatabaseListResponse(databases);
+  }
+
+  /** 指定データベースのカラム一覧取得 */
+  @UseGuards(JwtAuthGuard)
+  @Get(':id/columns')
+  @ApiParam({
+    name: 'id',
+    example: 'e9b3f1c2-...',
+    description: 'Notion DB の ID（実体は data_source_id）',
+  })
+  @ApiResponse({ status: 200, type: NotionColumnListResponse })
+  async getColumns(
+    @GetUserId() userId: string,
+    @Param('id') databaseId: string,
+  ): Promise<NotionColumnListResponse> {
+    const detail = await this.dataService.getDatabaseDetail(userId, databaseId);
+    return new NotionColumnListResponse(detail);
+  }
+
+  /** 全件Card化してdeckに一括INSERT */
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/import')
+  @ApiParam({
+    name: 'id',
+    example: 'e9b3f1c2-...',
+    description: 'Notion DB の ID（実体は data_source_id）',
+  })
+  @ApiResponse({ status: 201, type: NotionImportResponse })
+  async importDatabase(
+    @GetUserId() userId: string,
+    @Param('id') databaseId: string,
+    @Body() request: NotionImportRequest,
+  ): Promise<NotionImportResponse> {
+    const result = await this.dataService.importDatabase({
+      userId,
+      databaseId,
+      deckId: request.deckId,
+      columnName: request.columnName,
+    });
+    return new NotionImportResponse(result.count, result.truncated);
+  }
+}

--- a/backend/src/integrations/notion/notion-data.service.ts
+++ b/backend/src/integrations/notion/notion-data.service.ts
@@ -1,0 +1,66 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { NotionApiClient } from './notion-api.client';
+import {
+  NotionDatabaseDetail,
+  NotionDatabaseSummary,
+  NotionMapper,
+} from './notion.mapper';
+import { ICardRepository } from '../../card/card.repository.interface';
+
+/**
+ * Notion 連携データ取得サービス
+ */
+@Injectable()
+export class NotionDataService {
+  constructor(
+    private readonly apiClient: NotionApiClient,
+    private readonly mapper: NotionMapper,
+    // CardService と揃えて token 経由で注入
+    @Inject('ICardRepository')
+    private readonly cardRepository: ICardRepository,
+  ) {}
+
+  /** データベース一覧を返す */
+  async getDatabases(userId: string): Promise<NotionDatabaseSummary[]> {
+    const results = await this.apiClient.searchDatabases(userId);
+    return this.mapper.toDatabases(results);
+  }
+
+  /** 指定DBのカラム一覧を返す */
+  async getDatabaseDetail(
+    userId: string,
+    databaseId: string,
+  ): Promise<NotionDatabaseDetail> {
+    const database = await this.apiClient.retrieveDatabase(userId, databaseId);
+    return this.mapper.toDatabaseDetail(database);
+  }
+
+  /**
+   * 全件Card化してdeckに一括INSERT
+   * @returns 作成数と truncated フラグ（1000件で打ち切った場合 true）
+   */
+  async importDatabase(input: {
+    userId: string;
+    databaseId: string;
+    deckId: string;
+    columnName: string;
+  }): Promise<{ count: number; truncated: boolean }> {
+    // Notion から全 page を取得
+    const { pages, truncated } = await this.apiClient.queryDatabaseAll(
+      input.userId,
+      input.databaseId,
+    );
+
+    // pageをCardDtoへ変換
+    const notes = this.mapper.toNotes(pages, input.columnName);
+
+    // 認可チェック + 一括INSERTはrepository に任せる
+    const count = await this.cardRepository.createManyNote({
+      userId: input.userId,
+      deckId: BigInt(input.deckId),
+      rawNotes: notes,
+    });
+
+    return { count, truncated };
+  }
+}

--- a/backend/src/integrations/notion/notion.module.ts
+++ b/backend/src/integrations/notion/notion.module.ts
@@ -1,21 +1,26 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../../auth/auth.module';
+import { CardModule } from '../../card/card.module';
 import { EncryptionModule } from '../../common/encryption/encryption.module';
 import { PrismaModule } from '../../prisma/prisma.module';
 import { NotionApiClient } from './notion-api.client';
+import { NotionDataController } from './notion-data.controller';
+import { NotionDataService } from './notion-data.service';
 import { NotionIntegrationRepository } from './notion-integration.repository';
 import { NotionMapper } from './notion.mapper';
 import { NotionOAuthController } from './notion-oauth.controller';
 import { NotionOAuthService } from './notion-oauth.service';
 
 @Module({
-  imports: [PrismaModule, EncryptionModule, AuthModule],
-  controllers: [NotionOAuthController],
+  imports: [PrismaModule, EncryptionModule, AuthModule, CardModule],
+  controllers: [NotionOAuthController, NotionDataController],
   providers: [
     NotionOAuthService,
     NotionIntegrationRepository,
+    // Notion データ取得層
     NotionApiClient,
     NotionMapper,
+    NotionDataService,
   ],
   exports: [NotionOAuthService, NotionIntegrationRepository],
 })


### PR DESCRIPTION
## 概要
Notion-data importを作成した。メソッドは3つ。
1. DB一覧取得 （apiClientの薄いラッパ）
2. DBカラム取得 （apiClientの薄いラッパ）
3. 全page取得+cardにimport

## 詳細
- Card(Note)Repositoryの複数importではNotionの存在を知らない構造にした。Notionを知ると循環参照になるため避けなければいけない。
- Cardの複数importにおいてTransactionを使用した。なぜならインポートが途中で失敗した際に、DBに途中までのデータが残ると再インポートしたときに重複が出るため。
- Mapperの作成・apiClientの作成をserviceに直書きせず分けたことにより、serviceがシンプルになり可読性とテスト容易性が上がった。
- filterに関しては、apiclientで401を独自例外で投げるのだが、通常の401と混同するためその独自例外だけをcatchするfilterを作成した。
ただし、今回の例外処理に関して、SDKの例外を活かしきれていない。APIResponseErrorは複数の例外を内包し、それをcodeで分類している。
しかし、現行ではcodeを使っていないのでエラーの原因が分かりにくくなっている。
そのため今後リファクタする必要がある。

---
次はテスト。cardrepositoryの単体と全体の結合試験。