### PR TITLE
Feat/change notion exception handling

### DIFF
--- a/backend/src/integrations/notion/data/notion-api.client.spec.ts
+++ b/backend/src/integrations/notion/data/notion-api.client.spec.ts
@@ -2,7 +2,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { mockDeep, type DeepMockProxy } from 'vitest-mock-extended';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { BadGatewayException, UnauthorizedException } from '@nestjs/common';
+import { UnauthorizedException } from '@nestjs/common';
 import { APIResponseError, RequestTimeoutError } from '@notionhq/client';
 import type {
   DataSourceObjectResponse,
@@ -14,7 +14,12 @@ import type {
 import { NotionApiClient } from './notion-api.client';
 import { NotionIntegrationRepository } from '../notion-integration.repository';
 import { NotionOAuthService } from '../oauth/notion-oauth.service';
-import { NotionReauthRequiredException } from '../notion.exceptions';
+import {
+  NotionReauthRequiredException,
+  NotionRetryableException,
+  NotionServerErrorException,
+  NotionUserActionException,
+} from '../notion.exceptions';
 
 /**
  * @notionhq/client のモック
@@ -129,12 +134,12 @@ const buildUnauthorizedError = () =>
     request_id: undefined,
   });
 
-/** 5xx APIResponseError を作る */
-const buildServerError = () =>
+/** 任意 code の APIResponseError を作る（toNotionException の分類検証用） */
+const buildApiError = (code: string, status: number) =>
   new APIResponseError({
-    code: 'internal_server_error' as never,
-    status: 500,
-    message: 'internal_server_error',
+    code: code as never,
+    status,
+    message: code,
     headers: new Headers(),
     rawBodyText: '{}',
     additional_data: undefined,
@@ -294,21 +299,85 @@ describe('NotionApiClient', () => {
     });
   });
 
-  describe('withRetry: その他のエラー', () => {
-    it('異常系: 5xx → BadGatewayException', async () => {
-      mockSearch.mockRejectedValue(buildServerError());
+  describe('withRetry: handleFetchError による分類の確認', () => {
+    // 再試行できる例外
+    // 5xx 系と RequestTimeoutError は「Notion 側の一時障害」扱いとして同じ区分にまとまる
+    it.each([
+      ['internal_server_error', 500],
+      ['service_unavailable', 503],
+      ['gateway_timeout', 504],
+      ['rate_limited', 429],
+    ])(
+      '異常系: %s (%d) → NotionRetryableException (sdkCode=%s)',
+      async (code, status) => {
+        mockSearch.mockRejectedValue(buildApiError(code, status));
 
-      await expect(client.searchDatabases('user-1')).rejects.toBeInstanceOf(
-        BadGatewayException,
+        const error: unknown = await client
+          .searchDatabases('user-1')
+          .catch((e: unknown) => e);
+
+        expect(error).toBeInstanceOf(NotionRetryableException);
+        // sdkCode が SDK の code をそのまま保持していること（ログ追跡用）
+        expect((error as NotionRetryableException).sdkCode).toBe(code);
+      },
+    );
+
+    it('異常系: RequestTimeoutError → NotionRetryableException (sdkCode=request_timeout)', async () => {
+      mockSearch.mockRejectedValue(new RequestTimeoutError('timeout'));
+
+      const error: unknown = await client
+        .searchDatabases('user-1')
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(NotionRetryableException);
+      expect((error as NotionRetryableException).sdkCode).toBe(
+        'request_timeout',
       );
     });
 
-    it('異常系: RequestTimeoutError → BadGatewayException', async () => {
-      mockSearch.mockRejectedValue(new RequestTimeoutError('timeout'));
+    // ユーザ操作起因の例外
+    // ユーザが Notion 側で共有解除/削除した場合などはこちらに分類される
+    it.each([
+      ['restricted_resource', 403],
+      ['object_not_found', 404],
+    ])(
+      '異常系: %s (%d) → NotionUserActionException (sdkCode=%s)',
+      async (code, status) => {
+        mockSearch.mockRejectedValue(buildApiError(code, status));
 
-      await expect(client.searchDatabases('user-1')).rejects.toBeInstanceOf(
-        BadGatewayException,
+        const error: unknown = await client
+          .searchDatabases('user-1')
+          .catch((e: unknown) => e);
+
+        expect(error).toBeInstanceOf(NotionUserActionException);
+        expect((error as NotionUserActionException).sdkCode).toBe(code);
+      },
+    );
+
+    // サーバエラー例外
+    // validation_error 等の「組み立てミス」と、SDK 外の予期しない例外
+    it('異常系: validation_error → NotionServerErrorException (sdkCode=validation_error)', async () => {
+      mockSearch.mockRejectedValue(buildApiError('validation_error', 400));
+
+      const error: unknown = await client
+        .searchDatabases('user-1')
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(NotionServerErrorException);
+      expect((error as NotionServerErrorException).sdkCode).toBe(
+        'validation_error',
       );
+    });
+
+    it('異常系: SDK外の予期しない例外 → NotionServerErrorException (sdkCode=unknown)', async () => {
+      mockSearch.mockRejectedValue(new Error('boom'));
+
+      const error: unknown = await client
+        .searchDatabases('user-1')
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(NotionServerErrorException);
+      expect((error as NotionServerErrorException).sdkCode).toBe('unknown');
     });
 
     it('異常系: integration が見つからない → UnauthorizedException', async () => {

--- a/backend/src/integrations/notion/data/notion-api.client.ts
+++ b/backend/src/integrations/notion/data/notion-api.client.ts
@@ -1,5 +1,4 @@
 import {
-  BadGatewayException,
   HttpException,
   Injectable,
   Logger,
@@ -9,6 +8,7 @@ import {
   APIErrorCode,
   APIResponseError,
   Client,
+  RequestTimeoutError,
   isFullDataSource,
   isFullPage,
   iteratePaginatedAPI,
@@ -21,7 +21,12 @@ import type {
 } from '@notionhq/client/build/src/api-endpoints';
 import { NotionIntegrationRepository } from '../notion-integration.repository';
 import { NotionOAuthService } from '../oauth/notion-oauth.service';
-import { NotionReauthRequiredException } from '../notion.exceptions';
+import {
+  NotionReauthRequiredException,
+  NotionServerErrorException,
+  NotionRetryableException,
+  NotionUserActionException,
+} from '../notion.exceptions';
 
 /**
  * Notion API クライアント（SDK ラッパー）
@@ -66,9 +71,8 @@ export class NotionApiClient {
       client.dataSources.retrieve({ data_source_id: databaseId }),
     );
     if (!isFullDataSource(res)) {
-      throw new BadGatewayException(
-        'Notionからdatabaseの詳細を取得できませんでした。',
-      );
+      // SDK側のバグ
+      throw new NotionServerErrorException('not_full_data_source');
     }
     // 絞り込まず全カラムを返却（ユーザに選択させる）
     return res;
@@ -126,7 +130,7 @@ export class NotionApiClient {
           return await this.runWithClient(userId, fn);
         } catch (e2) {
           if (
-            // Notion AT/RTが無効な場合
+            // Refreshしても AT/RTが無効な場合
             e2 instanceof APIResponseError &&
             e2.code === APIErrorCode.Unauthorized
           ) {
@@ -134,11 +138,11 @@ export class NotionApiClient {
             throw new NotionReauthRequiredException();
           }
           // UNAUTHORIZED以外のエラーをハンドル（refresh後）
-          return this.handleNonRetryableError(e2);
+          this.handleFetchError(e2);
         }
       }
       // UNAUTHORIZED以外のエラーをハンドル（初回）
-      return this.handleNonRetryableError(e);
+      this.handleFetchError(e);
     }
   }
 
@@ -157,20 +161,40 @@ export class NotionApiClient {
   }
 
   /**
-   * 401以外のエラーを502に正規化
-   * - ネットワークエラーやタイムアウト、Notion障害、その他予期しない例外
-   * - HttpExceptionはそのまま流す
+   * fetchWithRetry で発生した NotionReauthRequiredException 以外の例外を分類して投げる
    */
-  private handleNonRetryableError(e: unknown): never {
-    if (e instanceof HttpException) throw e; // filterに丸投げ
-    if (e instanceof APIResponseError) {
-      throw new BadGatewayException(
-        `Notion API がエラーを返しました（status=${e.status}）。`,
-      );
+  private handleFetchError(e: unknown): never {
+    // 普通のhttpExはglobalFilterに丸投げ
+    if (e instanceof HttpException) throw e;
+
+    // 通信タイムアウト → ユーザに再試行させる
+    if (e instanceof RequestTimeoutError) {
+      throw new NotionRetryableException('request_timeout');
     }
-    // 予期しないエラーまたはネットワークエラー
-    this.logger.error('Notion APIへの通信が失敗しました', e);
-    throw new BadGatewayException('Notion APIとの通信に失敗しました。');
+    // Notion SDK の例外を3区分（再試行 / ユーザ操作 / サーバエラー）の
+    // 自前例外に分類する。詳細な SDK コードは sdkCode に格納してログで利用する
+    if (e instanceof APIResponseError) {
+      switch (e.code) {
+        // 再試行で解決する可能性のあるエラー
+        case APIErrorCode.RateLimited:
+        case APIErrorCode.InternalServerError:
+        case APIErrorCode.ServiceUnavailable:
+        case APIErrorCode.GatewayTimeout:
+          throw new NotionRetryableException(e.code);
+
+        // ユーザ側の設定起因（権限なし／対象が存在しない）
+        case APIErrorCode.RestrictedResource:
+        case APIErrorCode.ObjectNotFound:
+          throw new NotionUserActionException(e.code);
+
+        // それ以外はこちらのバグなのでサーバエラー扱い
+        default:
+          throw new NotionServerErrorException(e.code);
+      }
+    }
+
+    // SDK 外の例外（ネットワーク切断・UnknownHTTPResponseError 等）
+    throw new NotionServerErrorException('unknown');
   }
 
   /** RTを使ってAT/RTを再発行しDBを更新する。RT拒否ならintegrationを削除する */
@@ -193,7 +217,8 @@ export class NotionApiClient {
         );
         await this.repository.delete(userId);
         // 再連携要求はNotionApiExceptionFilterで識別され、
-        // body の code フィールドでフロントが再連携モーダルを出す
+        // body の code='NOTION_REAUTH_REQUIRED' を見たフロントが
+        // 連携解除ボタン→連携ボタンに状態を戻し、トーストを出す。
         throw new NotionReauthRequiredException(
           'Notion連携が無効になりました。再連携してください。',
         );

--- a/backend/src/integrations/notion/data/notion-api.exception.filter.ts
+++ b/backend/src/integrations/notion/data/notion-api.exception.filter.ts
@@ -1,30 +1,54 @@
 import { ArgumentsHost, Catch, ExceptionFilter, Logger } from '@nestjs/common';
 import { Request, Response } from 'express';
-import { NotionReauthRequiredException } from '../notion.exceptions';
+import {
+  NotionException,
+  NotionReauthRequiredException,
+  NotionServerErrorException,
+} from '../notion.exceptions';
 
 /**
  * Notion APIエンドポイント用の例外フィルタ
  *
- * フロント側で JWT 期限切れ等の通常 401 と区別する必要があるため、
- *  再連携要求にだけ専用 `code` を載せて返す。
+ * - NotionExceptionを一括 catch し、サブクラスごとに以下を出し分ける:
+ *   - ログ severity: NotionServerErrorException のみ error（スタック付き）、他は warn
+ *   - レスポンス body: 再連携要求のみ `code: 'NOTION_REAUTH_REQUIRED'` を付与する。
+ *     フロントは通常 401(JWT切れ) と区別したいケースのみ code を見て、
+ *     連携解除ボタン→連携ボタンへの状態遷移に使う。
  */
-@Catch(NotionReauthRequiredException)
+@Catch(NotionException)
 export class NotionApiExceptionFilter implements ExceptionFilter {
   private readonly logger = new Logger(NotionApiExceptionFilter.name);
 
-  catch(exception: NotionReauthRequiredException, host: ArgumentsHost) {
+  catch(exception: NotionException, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const res = ctx.getResponse<Response>();
     const req = ctx.getRequest<Request>();
     const status = exception.getStatus();
 
-    // ユーザ操作起因の業務エラー想定。スタックトレースまでは要らないので warn。
-    this.logger.warn(`${exception.message} - Path: ${req.url}`);
+    // SDK code（または独自タグ）を必ず付けてログに残す。
+    const logLine = `[${exception.sdkCode}] ${exception.message} - ${req.url}`;
 
-    // 再連携要求: フロントが他の 401 と区別できるよう専用 code を載せる
+    // サーバ起因（こちらのバグ示唆）だけ error + stack を残す。
+    if (exception instanceof NotionServerErrorException) {
+      this.logger.error(logLine, exception.stack);
+    } else {
+      this.logger.warn(logLine);
+    }
+
+    // 再連携要求のときだけ body に code を載せる（フロントのボタン状態遷移用）
+    if (exception instanceof NotionReauthRequiredException) {
+      return res.status(status).json({
+        statusCode: status,
+        code: 'NOTION_REAUTH_REQUIRED',
+        message: exception.message,
+        timestamp: new Date().toISOString(),
+        path: req.url,
+      });
+    }
+
+    // 通常の Notion 系例外
     return res.status(status).json({
       statusCode: status,
-      code: 'NOTION_REAUTH_REQUIRED',
       message: exception.message,
       timestamp: new Date().toISOString(),
       path: req.url,

--- a/backend/src/integrations/notion/notion.exceptions.ts
+++ b/backend/src/integrations/notion/notion.exceptions.ts
@@ -2,9 +2,13 @@ import { HttpException, HttpStatus } from '@nestjs/common';
 
 /**
  * Notion 連携専用の例外の基底クラス
- * これをcatchするのはNotionApiExceptionFilter
+ *
+ * - これを継承した例外は NotionApiExceptionFilter がまとめて catch する。
+ * - `sdkCode` は SDK のエラーコード（rate_limited 等）または独自タグ（reauth_required 等）。
+ *   フロントには返さず、サーバ側ログの分類用にのみ使う。
  */
 export abstract class NotionException extends HttpException {
+  abstract readonly sdkCode: string;
   constructor(message: string, status: HttpStatus) {
     super(message, status);
   }
@@ -18,6 +22,7 @@ export abstract class NotionException extends HttpException {
  * フィルタ漏れの保険としてサーバ側でも投げる。
  */
 export class NotionUnsupportedColumnException extends NotionException {
+  readonly sdkCode = 'unsupported_column';
   constructor(columnName: string, type: string) {
     super(
       `このカラム (${columnName}, type=${type}) は対応外です。title または rich_text のカラムを選択してください。`,
@@ -28,7 +33,48 @@ export class NotionUnsupportedColumnException extends NotionException {
 
 /** Notion連携が無効になり、ユーザに再連携を要求する必要がある場合の例外 */
 export class NotionReauthRequiredException extends NotionException {
+  readonly sdkCode = 'reauth_required';
   constructor(message = 'Notion連携が無効です。再連携してください。') {
     super(message, HttpStatus.UNAUTHORIZED);
+  }
+}
+
+// SDKから出る例外
+/**
+ * 再試行で解決する可能性がある一時的なエラー。
+ * 例: rate_limited / internal_server_error / service_unavailable / gateway_timeout / RequestTimeout
+ *
+ * フロントには 503 と定型メッセージを返す。
+ */
+export class NotionRetryableException extends NotionException {
+  constructor(readonly sdkCode: string) {
+    super(
+      '一時的な障害が発生しました。時間をおいて再度お試しください。',
+      HttpStatus.SERVICE_UNAVAILABLE,
+    );
+  }
+}
+
+/**
+ * ユーザ側の設定問題に起因するエラー。
+ * 例: restricted_resource / object_not_found（DB を共有していない・削除した等）
+ *
+ * フロントには 400 と「連携設定を確認してください」を返す。
+ */
+export class NotionUserActionException extends NotionException {
+  constructor(readonly sdkCode: string) {
+    super('Notionとの連携設定を確認してください。', HttpStatus.BAD_REQUEST);
+  }
+}
+
+/**
+ * こちら側のバグ・想定外を示すエラー。
+ * 例: validation_error / invalid_json / invalid_request / SDK 以外の例外
+ *
+ * フロントには 500 と汎用メッセージを返し、サーバ側はスタックトレース付きで error ログを残す。
+ */
+export class NotionServerErrorException extends NotionException {
+  constructor(readonly sdkCode: string) {
+    super('システムエラーが発生しました。', HttpStatus.INTERNAL_SERVER_ERROR);
   }
 }

--- a/backend/test/integrations/notion/notion-data.integration-spec.ts
+++ b/backend/test/integrations/notion/notion-data.integration-spec.ts
@@ -356,8 +356,9 @@ describe('Notion Data (Integration)', () => {
       expect(mockDataSourcesRetrieve).not.toHaveBeenCalled();
     });
 
-    it('2-3: 異常系 - Notion応答が isFullDataSource を通らない → 502', async () => {
-      // mapper にたどり着く前に APIClient の型ガードで弾かれ502
+    it('2-3: 異常系 - Notion応答が isFullDataSource を通らない → 500', async () => {
+      // mapper にたどり着く前に APIClient の型ガードで弾かれる。
+      // SDK 応答の想定外形状＝こちら側のバグ示唆として NotionServerErrorException(500) に分類
       await seedNotionIntegration();
       mockDataSourcesRetrieve.mockResolvedValue({
         id: 'ds-1', // 通らないデータ
@@ -366,7 +367,7 @@ describe('Notion Data (Integration)', () => {
       await request(app.getHttpServer())
         .get('/integrations/notion/databases/ds-1/columns')
         .set('Authorization', `Bearer ${token}`)
-        .expect(HttpStatus.BAD_GATEWAY);
+        .expect(HttpStatus.INTERNAL_SERVER_ERROR);
     });
   });
 
@@ -447,7 +448,7 @@ describe('Notion Data (Integration)', () => {
       );
     });
 
-    it('3-3: 異常系 - Notion API 途中失敗（2ページ目で 5xx）→ 502、card 変動なし', async () => {
+    it('3-3: 異常系 - Notion API 途中失敗（2ページ目で 5xx）→ 503、card 変動なし', async () => {
       await seedNotionIntegration();
       // 1ページ目: 100件 + has_more=true で 2ページ目を要求
       const firstPage = Array.from({ length: 100 }, (_, i) =>
@@ -456,13 +457,14 @@ describe('Notion Data (Integration)', () => {
       mockDataSourcesQuery
         .mockResolvedValueOnce(buildQueryResponse(firstPage, true, 'c1'))
         // 2ページ目: Notion 5xx
+        // → NotionRetryableException に分類されてフロントには 503 を返す
         .mockRejectedValueOnce(buildServerError());
 
       await request(app.getHttpServer())
         .post('/integrations/notion/databases/ds-1/import')
         .set('Authorization', `Bearer ${token}`)
         .send({ deckId: myDeckId.toString(), columnName: 'Body' })
-        .expect(HttpStatus.BAD_GATEWAY);
+        .expect(HttpStatus.SERVICE_UNAVAILABLE);
 
       // createManyNote まで到達していないので card は0件
       expect(await prisma.card.count({ where: { deckId: myDeckId } })).toBe(0);


### PR DESCRIPTION
## 概要
既存のコードでは、SDKから発生する例外がきちんと整理されておらず、
ログで詳細が把握できないかつ、フロントでトーストの出しわけができないという問題があった。
そのため、発生する例外を３つに分類してそれぞれ自前例外に当てはめたうえでfilterによりログとフロントへの返却を実現する。

## 詳細

SDKから発生する例外はユーザに提示するという軸で分類すると、主に以下の三つに分けられる。
- 再試行可能な例外　NotionRetryableException
- ユーザ起因の問題　NotionUserActionException
- バグ・予期しないエラー　NotionServerErrorException

上二つは単にログを出してフロントにメッセージを返すだけ。
最後のサーバーエラーに関してはlog+stacktraceを出す。

コードの流れとして、
1. fetchWithRetryで例外発生
2. handleFetchErrorで発生した例外をcodeで３つに分類して独自例外をスロー
3. notion-api.fitlerが独自例外をキャッチしてログ+メッセージを作成。

### 補足
RTが拒否された場合は NotionReauthRequiredExceptionが投げられて、
filterでCode付きで返却される。このcodeはsdkcodeではなく、フロントが
ただの401と NotionReauthRequiredExceptionを見分けるためのもの。
 NotionReauthRequiredExceptionを受け取ると、フロントで連携ボタンの状態遷移とトーストを出す仕組みを考えている。
 
Closes #148 
