### PR TITLE
Feat/change oauth exception handling

### DIFF
--- a/backend/src/integrations/notion/notion.exceptions.ts
+++ b/backend/src/integrations/notion/notion.exceptions.ts
@@ -39,6 +39,33 @@ export class NotionReauthRequiredException extends NotionException {
   }
 }
 
+// OAuth callback 専用の例外
+/**
+ * OAuth callback でのクライアント起因エラー。
+ * 例: state 不正 / code 欠落 / cookie 欠落
+ */
+export class NotionOAuthInvalidRequestException extends NotionException {
+  constructor(
+    readonly sdkCode: string,
+    message: string,
+  ) {
+    super(message, HttpStatus.BAD_REQUEST);
+  }
+}
+
+/**
+ * OAuth callback での Notion / 内部ロジック起因エラー。
+ * 例: token エンドポイントの APIResponseError / 通信エラー / レスポンス不正
+ */
+export class NotionOAuthInternalException extends NotionException {
+  constructor(
+    readonly sdkCode: string,
+    message: string,
+  ) {
+    super(message, HttpStatus.BAD_GATEWAY);
+  }
+}
+
 // SDKから出る例外
 /**
  * 再試行で解決する可能性がある一時的なエラー。

--- a/backend/src/integrations/notion/oauth/notion-oauth.controller.spec.ts
+++ b/backend/src/integrations/notion/oauth/notion-oauth.controller.spec.ts
@@ -2,8 +2,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { mockDeep, type DeepMockProxy } from 'vitest-mock-extended';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { BadRequestException } from '@nestjs/common';
 import type express from 'express';
+import { NotionOAuthInvalidRequestException } from '../notion.exceptions';
 
 // controller.ts は import 時に process.env.FRONTEND_URL を読み込んで定数に固定する。
 // そのため vi.hoisted を使い、import より前に env を設定しておく必要がある。
@@ -125,7 +125,7 @@ describe('NotionOAuthController.callback', () => {
   // state検証
   // ---------------------------------------------------------------------------
   describe('state検証', () => {
-    it('異常系: queryState と cookieState が不一致 → BadRequestException', async () => {
+    it('異常系: queryState と cookieState が不一致 → NotionOAuthInvalidRequestException', async () => {
       const req = makeReq({
         [COOKIE_OAUTH_STATE]: 'cookie-state',
         [COOKIE_OAUTH_DECK_ID]: 'deck-99',
@@ -135,14 +135,14 @@ describe('NotionOAuthController.callback', () => {
 
       await expect(
         controller.callback('code', 'query-state', undefined, req, res),
-      ).rejects.toBeInstanceOf(BadRequestException);
+      ).rejects.toBeInstanceOf(NotionOAuthInvalidRequestException);
 
       // 状態不正なので service は呼ばれない
       expect(serviceMock.exchangeCodeForTokens).not.toHaveBeenCalled();
       expect(serviceMock.saveNotionResponse).not.toHaveBeenCalled();
     });
 
-    it('異常系: cookieState 自体が無い → BadRequestException', async () => {
+    it('異常系: cookieState 自体が無い → NotionOAuthInvalidRequestException', async () => {
       // [試験項目: cookie state 欠落]
       // Cookie の有効期限切れ・別オリジン経由など、cookieState が落ちているケース
       const req = makeReq({
@@ -153,10 +153,10 @@ describe('NotionOAuthController.callback', () => {
 
       await expect(
         controller.callback('code', 'some-state', undefined, req, res),
-      ).rejects.toBeInstanceOf(BadRequestException);
+      ).rejects.toBeInstanceOf(NotionOAuthInvalidRequestException);
     });
 
-    it('異常系: queryState が無い → BadRequestException', async () => {
+    it('異常系: queryState が無い → NotionOAuthInvalidRequestException', async () => {
       const req = makeReq({
         [COOKIE_OAUTH_STATE]: 'cookie-state',
         [COOKIE_OAUTH_DECK_ID]: 'deck-99',
@@ -166,7 +166,7 @@ describe('NotionOAuthController.callback', () => {
 
       await expect(
         controller.callback('code', undefined, undefined, req, res),
-      ).rejects.toBeInstanceOf(BadRequestException);
+      ).rejects.toBeInstanceOf(NotionOAuthInvalidRequestException);
     });
   });
 
@@ -200,7 +200,7 @@ describe('NotionOAuthController.callback', () => {
       );
     });
 
-    it('error あり & state不一致 → state不一致が優先で BadRequestException', async () => {
+    it('error あり & state不一致 → state不一致が優先で NotionOAuthInvalidRequestException', async () => {
       // state 検証が最初に走るため、error の有無に関わらず BadRequest が出るのが期待挙動。
       const req = makeReq({
         [COOKIE_OAUTH_STATE]: 'cookie-state',
@@ -217,7 +217,7 @@ describe('NotionOAuthController.callback', () => {
           req,
           res,
         ),
-      ).rejects.toBeInstanceOf(BadRequestException);
+      ).rejects.toBeInstanceOf(NotionOAuthInvalidRequestException);
 
       // cancelled redirect は走らない
       expect(res.redirect).not.toHaveBeenCalled();
@@ -230,7 +230,7 @@ describe('NotionOAuthController.callback', () => {
   describe('必須項目チェック（state一致後）', () => {
     const state = 'STATE-OK';
 
-    it('異常系: code が undefined → BadRequestException', async () => {
+    it('異常系: code が undefined → NotionOAuthInvalidRequestException', async () => {
       const req = makeReq({
         [COOKIE_OAUTH_STATE]: state,
         [COOKIE_OAUTH_DECK_ID]: 'deck-99',
@@ -240,12 +240,12 @@ describe('NotionOAuthController.callback', () => {
 
       await expect(
         controller.callback(undefined, state, undefined, req, res),
-      ).rejects.toBeInstanceOf(BadRequestException);
+      ).rejects.toBeInstanceOf(NotionOAuthInvalidRequestException);
 
       expect(serviceMock.exchangeCodeForTokens).not.toHaveBeenCalled();
     });
 
-    it('異常系: userId Cookie が無い → BadRequestException', async () => {
+    it('異常系: userId Cookie が無い → NotionOAuthInvalidRequestException', async () => {
       // [試験項目: userId Cookie 欠落]
       const req = makeReq({
         [COOKIE_OAUTH_STATE]: state,
@@ -256,12 +256,12 @@ describe('NotionOAuthController.callback', () => {
 
       await expect(
         controller.callback('code', state, undefined, req, res),
-      ).rejects.toBeInstanceOf(BadRequestException);
+      ).rejects.toBeInstanceOf(NotionOAuthInvalidRequestException);
 
       expect(serviceMock.exchangeCodeForTokens).not.toHaveBeenCalled();
     });
 
-    it('異常系: deckId Cookie が無い → BadRequestException', async () => {
+    it('異常系: deckId Cookie が無い → NotionOAuthInvalidRequestException', async () => {
       const req = makeReq({
         [COOKIE_OAUTH_STATE]: state,
         [COOKIE_OAUTH_USER_ID]: 'user-1',
@@ -271,7 +271,7 @@ describe('NotionOAuthController.callback', () => {
 
       await expect(
         controller.callback('code', state, undefined, req, res),
-      ).rejects.toBeInstanceOf(BadRequestException);
+      ).rejects.toBeInstanceOf(NotionOAuthInvalidRequestException);
 
       expect(serviceMock.exchangeCodeForTokens).not.toHaveBeenCalled();
     });

--- a/backend/src/integrations/notion/oauth/notion-oauth.controller.ts
+++ b/backend/src/integrations/notion/oauth/notion-oauth.controller.ts
@@ -22,6 +22,7 @@ import {
   NotionTokenResponse,
 } from './notion-oauth.service';
 import { NotionOAuthExceptionFilter } from './notion-oauth.exception.filter';
+import { NotionOAuthInvalidRequestException } from '../notion.exceptions';
 import {
   COOKIE_MAX_AGE,
   COOKIE_OAUTH_DECK_ID,
@@ -66,6 +67,7 @@ export class NotionOAuthController {
     res.cookie(COOKIE_OAUTH_USER_ID, userId, cookieOptions);
 
     // Notion認可画面URLを返す（フロントがwindow.location.hrefで遷移する）
+    // リダイレクトするとATが乗せれずに認証が効かない(401)
     const authorizationUrl =
       this.notionOAuthService.buildAuthorizationUrl(state);
     return new NotionAuthStartResponse(authorizationUrl);
@@ -97,7 +99,10 @@ export class NotionOAuthController {
     /** バリデーション */
     // state検証（CSRF対策）クエリが偽造されている可能性有
     if (!queryState || !cookieState || queryState !== cookieState) {
-      throw new BadRequestException('state が不正、または期限切れです。');
+      throw new NotionOAuthInvalidRequestException(
+        'state_mismatch',
+        'state が不正、または期限切れです。',
+      );
     } else {
       // ユーザがNotion側で認可拒否した場合
       if (error) {
@@ -109,14 +114,23 @@ export class NotionOAuthController {
       }
       // 認可codeが無ければ中止
       if (!code) {
-        throw new BadRequestException('code が含まれていません。');
+        throw new NotionOAuthInvalidRequestException(
+          'missing_code',
+          'code が含まれていません。',
+        );
       }
       // userId Cookie, deckId Cookieが無ければ中止
       if (!userId) {
-        throw new BadRequestException('userId Cookieが見つかりません。');
+        throw new NotionOAuthInvalidRequestException(
+          'missing_user_cookie',
+          'userId Cookieが見つかりません。',
+        );
       }
       if (!deckId) {
-        throw new BadRequestException('deckId Cookieが見つかりません。');
+        throw new NotionOAuthInvalidRequestException(
+          'missing_deck_cookie',
+          'deckId Cookieが見つかりません。',
+        );
       }
     }
 

--- a/backend/src/integrations/notion/oauth/notion-oauth.exception.filter.ts
+++ b/backend/src/integrations/notion/oauth/notion-oauth.exception.filter.ts
@@ -1,25 +1,28 @@
-import {
-  ArgumentsHost,
-  BadGatewayException,
-  BadRequestException,
-  Catch,
-  ExceptionFilter,
-  Logger,
-} from '@nestjs/common';
+import { ArgumentsHost, Catch, ExceptionFilter, Logger } from '@nestjs/common';
 import { Request, Response } from 'express';
+import {
+  NotionException,
+  NotionOAuthInternalException,
+  NotionOAuthInvalidRequestException,
+} from '../notion.exceptions';
 import {
   COOKIE_OAUTH_DECK_ID,
   clearOAuthCookies,
 } from './notion-oauth.cookies';
 
-@Catch(BadRequestException, BadGatewayException)
+/**
+ * Notion OAuth callback 用の例外フィルタ
+ *
+ * - OAuth 専用の独自例外（NotionException 派生）を catch し、フロントへリダイレクトで返す。
+ * - data 側 (NotionApiExceptionFilter) が JSON を返すのと異なり、callback はブラウザ遷移なので
+ *   notion_invalid / notion_failed のフラグを query に載せて redirect する。
+ * - notion_failed / notion_invalid の振り分けは instanceof で行い、例外クラス自身には持たせない。
+ */
+@Catch(NotionOAuthInvalidRequestException, NotionOAuthInternalException)
 export class NotionOAuthExceptionFilter implements ExceptionFilter {
   private readonly logger = new Logger(NotionOAuthExceptionFilter.name);
 
-  catch(
-    exception: BadRequestException | BadGatewayException,
-    host: ArgumentsHost,
-  ) {
+  catch(exception: NotionException, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const res: Response = ctx.getResponse<Response>();
     const req = ctx.getRequest<Request>();
@@ -27,27 +30,25 @@ export class NotionOAuthExceptionFilter implements ExceptionFilter {
     const cookies = req.cookies as Record<string, string | undefined>;
     const deckId = cookies[COOKIE_OAUTH_DECK_ID] ?? '/decks';
 
-    // BADREQUESTに関してはクライアント由来であり調査の必要性が薄い。
-    if (exception instanceof BadGatewayException) {
-      this.logger.error(exception.message, exception.stack);
-      // cause walk: SDK元エラー（APIResponseError等）も出す
-      const cause = (exception as Error).cause;
-      if (cause instanceof Error) {
-        this.logger.error(`Caused by: ${cause.message}`, cause.stack);
-      }
+    // SDK code（または独自タグ）を必ず付けてログに残す。
+    const logLine = `[${exception.sdkCode}] ${exception.message} - ${req.url}`;
+
+    // Notion / 内部ロジック起因（upstream）だけ error + stack を残す。
+    // クライアント起因（invalid）は調査の必要性が薄いので warn。
+    const isInternalException =
+      exception instanceof NotionOAuthInternalException;
+    if (isInternalException) {
+      this.logger.error(logLine, exception.stack);
     } else {
-      this.logger.warn(exception.message);
+      this.logger.warn(logLine);
     }
 
-    // cookieを破棄
+    // cookieを破棄（再利用防止）
     clearOAuthCookies(res);
 
     // notionからのリクエストから発生したエラーはフロントに返す必要がない。
     // つまりサーバー内部エラーであるためメッセージは返さずフラグで失敗かどうかの判断をさせる。
-    const code =
-      exception instanceof BadGatewayException
-        ? 'notion_failed'
-        : 'notion_invalid';
+    const code = isInternalException ? 'notion_failed' : 'notion_invalid';
     return res.redirect(
       `${process.env.FRONTEND_URL}/decks/${deckId}?integration=${code}`,
     );

--- a/backend/src/integrations/notion/oauth/notion-oauth.service.spec.ts
+++ b/backend/src/integrations/notion/oauth/notion-oauth.service.spec.ts
@@ -20,7 +20,10 @@ import {
 
 import { NotionOAuthService } from './notion-oauth.service';
 import { NotionIntegrationRepository } from '../notion-integration.repository';
-import { NotionReauthRequiredException } from '../notion.exceptions';
+import {
+  NotionOAuthInternalException,
+  NotionReauthRequiredException,
+} from '../notion.exceptions';
 
 /**
  * @notionhq/client (Notion 公式 SDK) のモック
@@ -160,8 +163,9 @@ describe('NotionOAuthService', () => {
       });
     });
 
-    // APIResponseError は Notion 側エラー（invalid_grant等）。service は内部用 message で投げ直す
-    it('異常系: APIResponseError → BadGateway (内部用 message)', async () => {
+    // APIResponseError は Notion 側エラー（invalid_grant等）。
+    // service は SDK の code を sdkCode に載せて NotionOAuthInternalException で投げ直す
+    it('異常系: APIResponseError → NotionOAuthInternalException (sdkCode=SDK code)', async () => {
       const apiErr = new APIResponseError({
         code: 'unauthorized' as never,
         status: 401,
@@ -173,24 +177,35 @@ describe('NotionOAuthService', () => {
       });
       mockOauthToken.mockRejectedValue(apiErr);
 
-      await expect(service.exchangeCodeForTokens('code')).rejects.toMatchObject(
-        {
-          constructor: BadGatewayException,
-          message: 'Notion連携に失敗しました。',
-        },
+      const error: unknown = await service
+        .exchangeCodeForTokens('code')
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(NotionOAuthInternalException);
+      // SDK の code がそのまま sdkCode に乗る（ログ追跡用）
+      expect((error as NotionOAuthInternalException).sdkCode).toBe(
+        'unauthorized',
+      );
+      expect((error as NotionOAuthInternalException).message).toBe(
+        'Notion連携に失敗しました。',
       );
     });
 
-    // それ以外（RequestTimeoutError / network 系）は通信用 message で投げ直す
-    it('異常系: RequestTimeoutError → BadGateway (通信用 message)', async () => {
+    // それ以外（RequestTimeoutError / network 系）は sdkCode=connection_error で投げ直す
+    it('異常系: RequestTimeoutError → NotionOAuthInternalException (sdkCode=connection_error)', async () => {
       const timeoutErr = new RequestTimeoutError('request timed out');
       mockOauthToken.mockRejectedValue(timeoutErr);
 
-      await expect(service.exchangeCodeForTokens('code')).rejects.toMatchObject(
-        {
-          constructor: BadGatewayException,
-          message: 'Notionへの接続に失敗しました。',
-        },
+      const error: unknown = await service
+        .exchangeCodeForTokens('code')
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(NotionOAuthInternalException);
+      expect((error as NotionOAuthInternalException).sdkCode).toBe(
+        'connection_error',
+      );
+      expect((error as NotionOAuthInternalException).message).toBe(
+        'Notionへの接続に失敗しました。',
       );
     });
 
@@ -200,13 +215,18 @@ describe('NotionOAuthService', () => {
       ['refresh_token が null', { refresh_token: null, workspace_name: 'n' }],
       ['workspace_name が null', { refresh_token: 'r', workspace_name: null }],
     ])(
-      '異常系: 必須項目欠落 (%s) → BadGatewayException',
+      '異常系: 必須項目欠落 (%s) → NotionOAuthInternalException (sdkCode=invalid_response)',
       async (_label, partial) => {
         mockOauthToken.mockResolvedValue(buildOauthResponse(partial));
 
-        await expect(
-          service.exchangeCodeForTokens('code'),
-        ).rejects.toBeInstanceOf(BadGatewayException);
+        const error: unknown = await service
+          .exchangeCodeForTokens('code')
+          .catch((e: unknown) => e);
+
+        expect(error).toBeInstanceOf(NotionOAuthInternalException);
+        expect((error as NotionOAuthInternalException).sdkCode).toBe(
+          'invalid_response',
+        );
       },
     );
   });

--- a/backend/src/integrations/notion/oauth/notion-oauth.service.ts
+++ b/backend/src/integrations/notion/oauth/notion-oauth.service.ts
@@ -7,7 +7,10 @@ import {
   APIResponseError,
   type OauthTokenResponse,
 } from '@notionhq/client';
-import { NotionReauthRequiredException } from '../notion.exceptions';
+import {
+  NotionOAuthInternalException,
+  NotionReauthRequiredException,
+} from '../notion.exceptions';
 
 /**
  * Notion OAuth tokenエンドポイントのレスポンス（必要項目のみ）
@@ -63,14 +66,25 @@ export class NotionOAuthService {
       });
     } catch (e) {
       // APIResponseError: Notion 側 4xx/5xx ／ それ以外: 通信系
+      // SDK の code（rate_limited 等）を sdkCode に載せてログに残す。
+      // フロントには filter が notion_failed フラグだけ返す。
       if (e instanceof APIResponseError) {
-        throw new BadGatewayException('Notion連携に失敗しました。');
+        throw new NotionOAuthInternalException(
+          e.code,
+          'Notion連携に失敗しました。',
+        );
       }
-      throw new BadGatewayException('Notionへの接続に失敗しました。');
+      throw new NotionOAuthInternalException(
+        'connection_error',
+        'Notionへの接続に失敗しました。',
+      );
     }
     // resがnullableなのでチェック
     if (!response.refresh_token || !response.workspace_name) {
-      throw new BadGatewayException('Notionからのレスポンスが不正です。');
+      throw new NotionOAuthInternalException(
+        'invalid_response',
+        'Notionからのレスポンスが不正です。',
+      );
     }
 
     // NotionTokenResponseを返す

--- a/backend/test/integrations/notion/notion-oauth.integration-spec.ts
+++ b/backend/test/integrations/notion/notion-oauth.integration-spec.ts
@@ -388,8 +388,9 @@ describe('Notion OAuth (Integration)', () => {
     });
 
     it('B-4: Notion API が 4xx (APIResponseError) → notion_failed redirect、Cookie clear、DB 変化なし', async () => {
-      // SDK 化後は service が APIResponseError を捕捉して BadGatewayException に詰め替える。
-      // それを NotionOAuthExceptionFilter が拾って notion_failed に倒す流れ。
+      // service が APIResponseError を捕捉し、code を sdkCode に載せて
+      // NotionOAuthUpstreamException に詰め替える。それを NotionOAuthExceptionFilter が
+      // 拾って notion_failed に倒す流れ。
       mockOauthToken.mockRejectedValue(
         buildApiResponseError(400, 'invalid_grant'),
       );
@@ -409,8 +410,8 @@ describe('Notion OAuth (Integration)', () => {
     });
 
     it('B-4b: 通信エラー (RequestTimeoutError) → notion_failed redirect、Cookie clear、DB 変化なし', async () => {
-      // SDK は通信失敗を RequestTimeoutError として返す。service 側は接続用の
-      // BadGatewayException に詰め替える。filter の出力は同じく notion_failed。
+      // SDK は通信失敗を RequestTimeoutError として返す。service 側は sdkCode=connection_error の
+      // NotionOAuthUpstreamException に詰め替える。filter の出力は同じく notion_failed。
       mockOauthToken.mockRejectedValue(
         new RequestTimeoutError('request timed out'),
       );
@@ -431,7 +432,7 @@ describe('Notion OAuth (Integration)', () => {
 
     it('B-5: Notion レスポンス必須項目欠落 → notion_failed redirect', async () => {
       // SDK 型上 refresh_token / workspace_name は nullable。null で来た時 service が
-      // BadGatewayException を投げ、filter が notion_failed に倒す。
+      // sdkCode=invalid_response の NotionOAuthUpstreamException を投げ、filter が notion_failed に倒す。
       mockOauthToken.mockResolvedValue(
         buildOauthResponse({
           refresh_token: null,


### PR DESCRIPTION
## 概要
OAuthの例外処理のリファクタリングを行った。
## 詳細
Notion-apiでは、APIResposeErrorを受け取って内部に持つcodeによってログ及びレスポンスのだし分けを行っていた。しかし、oauthではbadgateway, badrequestで握りつぶしていたので、適切なログ出力ができていなかった。
そこで、Notion-apiに倣ってcodeによるだし分けを行う。
ここで注意すべきなのは、変更する箇所はcallbackエンドポイントであり、このエンドポイントはNotion側から呼び出されるため、レスポンスを返す必要はなくログの出力だけおこなう。失敗時はurlパラメータにfailed かinvalidを返して、フロントでトーストのだし分けを行う。

---
次はフロントの作成とフロントの例外処理

Closes #153 