### PR TITLE
Feat/notion view button

### DIFF
--- a/frontend/app/(main)/decks/[deckId]/page.tsx
+++ b/frontend/app/(main)/decks/[deckId]/page.tsx
@@ -14,6 +14,8 @@ import CardEditModal from '@/features/card/components/CardEditModal';
 import DeckUpdateModal from '@/features/deck/components/DeckUpdateModal';
 import { useDeckMutations } from '@/features/deck/hooks/useDeckMutations';
 import { useNotionAuth } from '@/features/integration/notion/hooks/useNotionAuth';
+import { useNotionStatus } from '@/features/integration/notion/hooks/useNotionStatus';
+import { useNotionUrlResponse } from '@/features/integration/notion/hooks/useNotionUrlResponse';
 
 type Card = components['schemas']['CardResponse'];
 type CreateCardRequest = components['schemas']['CreateCardRequest'];
@@ -41,12 +43,16 @@ export default function CardListPage() {
   const { data: cards = [], isLoading, isError, error } = useCards(deckId);
   const { createCard, updateCard, deleteCard } = useCardMutations();
   const { updateDeck } = useDeckMutations();
-  const { connect: connectNotion } = useNotionAuth(deckId);
+  const { connect: connectNotion, disconnect: disconnectNotion } =
+    useNotionAuth(deckId);
+  const { data: notionStatus } = useNotionStatus();
+  useNotionUrlResponse(deckId);
 
   // useState（モーダル開閉）
   const [openEditDeck, setOpenEditDeck] = useState(false);
   const [openCreateCard, setOpenCreateCard] = useState(false);
   const [editingCard, setEditingCard] = useState<Card | null>(null);
+  const [openImport, setOpenImport] = useState(false);
 
   // CRUD
   //deck
@@ -81,6 +87,15 @@ export default function CardListPage() {
             onEditDeck={() => setOpenEditDeck(true)}
             onCreateCard={() => setOpenCreateCard(true)}
             onConnectNotion={() => connectNotion.mutate()}
+            onDisconnectNotion={() => {
+              if (window.confirm('Notion連携を解除しますか？')) {
+                disconnectNotion.mutate();
+              }
+            }}
+            onImport={() => setOpenImport(true)}
+            notionConnected={notionStatus?.connected ?? false}
+            notionConnecting={connectNotion.isPending}
+            notionDisconnecting={disconnectNotion.isPending}
           />
           <CardList
             cards={cards}
@@ -117,6 +132,8 @@ export default function CardListPage() {
           onSave={handleUpdateCard}
         />
       )}
+
+      {/* TODO: Step管理のNotionインポートモーダルに置き換える */}
     </div>
   );
 }

--- a/frontend/features/card/components/CardListPageHeader.tsx
+++ b/frontend/features/card/components/CardListPageHeader.tsx
@@ -7,6 +7,11 @@ type CardListPageHeaderProps = {
   onEditDeck: () => void;
   onCreateCard: () => void;
   onConnectNotion: () => void;
+  onDisconnectNotion: () => void; // 連携解除
+  onImport: () => void; // インポートモーダルを開く
+  notionConnected?: boolean; // Notion連携済みかどうか
+  notionConnecting?: boolean; // 連携開始リクエスト中の二重押下を防ぐ
+  notionDisconnecting?: boolean; // 連携解除リクエスト中の二重押下を防ぐ
 };
 
 export default function CardListPageHeader({
@@ -14,6 +19,11 @@ export default function CardListPageHeader({
   onEditDeck,
   onCreateCard,
   onConnectNotion,
+  onDisconnectNotion,
+  onImport,
+  notionConnected = false,
+  notionConnecting = false,
+  notionDisconnecting = false,
 }: CardListPageHeaderProps) {
   return (
     <div className="flex items-center justify-between px-8 py-5 border-b border-gray-200">
@@ -31,9 +41,32 @@ export default function CardListPageHeader({
 
       {/* 右：デッキ編集 + Notion連携 + カード追加 */}
       <div className="flex items-center gap-2">
-        <button onClick={onConnectNotion} className="btn btn-neutral btn-sm">
-          Notion連携
-        </button>
+        {/* 未連携：連携ボタン / 連携済み：解除ボタン＋インポートボタン */}
+        {!notionConnected ? (
+          <button
+            onClick={onConnectNotion}
+            disabled={notionConnecting}
+            className="btn btn-outline btn-neutral btn-sm"
+          >
+            Notion連携
+          </button>
+        ) : (
+          <>
+            <button
+              onClick={onImport}
+              className="btn btn-outline btn-neutral btn-sm"
+            >
+              Notionインポート
+            </button>
+            <button
+              onClick={onDisconnectNotion}
+              disabled={notionDisconnecting}
+              className="btn btn-outline btn-error btn-sm"
+            >
+              Notion連携解除
+            </button>
+          </>
+        )}
 
         <button
           onClick={onEditDeck}

--- a/frontend/features/integration/notion/hooks/useNotionAuth.ts
+++ b/frontend/features/integration/notion/hooks/useNotionAuth.ts
@@ -1,20 +1,23 @@
 import { apiClient } from '@/lib/api/client';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { components } from '@memo-anki/shared';
 import { HttpStatus } from '@/lib/api/statusCodes';
 import { toast } from 'sonner';
 import { HttpError } from '@/lib/api/httpError';
+import { NOTION_STATUS_QUERY_KEY } from './useNotionStatus';
 type NotionAuthStartResponse = components['schemas']['NotionAuthStartResponse'];
 
 /**
- * Notion OAuth 開始フック
+ * Notion OAuth 開始 / 連携解除フック
  *
- * Notion連携ボタンが押されたら、このロジックが起動する。
- * このロジックは/authに接続し、/authはNotionに渡すための情報を
- * 含めたリダイレクトURLを発行するので、そのURLを使ってNotion側の
- * 認証画面に移動する。
+ * - connect: Notion連携ボタンが押されたら起動する。/authに接続し、
+ *   発行されたリダイレクトURLを使ってNotion側の認証画面に移動する。
+ * - disconnect: 連携解除ボタンが押されたら起動する。連携情報を削除し、
+ *   状態を再取得してボタンを連携ボタンに戻す。
  */
 export const useNotionAuth = (deckId: string) => {
+  const queryClient = useQueryClient();
+
   const connect = useMutation<NotionAuthStartResponse>({
     mutationFn: () =>
       apiClient(
@@ -28,6 +31,33 @@ export const useNotionAuth = (deckId: string) => {
     },
 
     onError: (err) => {
+      if (err instanceof HttpError) {
+        // JWTセッション切れ（apiClientがrefresh再試行してもなお401）
+        if (err.statusCode === HttpStatus.UNAUTHORIZED) {
+          toast.error('ログインし直してください');
+          return;
+        }
+        // deckId不正等のクライアント起因（globalfilterがJSONで返す）
+        if (err.statusCode === HttpStatus.BAD_REQUEST) {
+          toast.error('不正なリクエストです。');
+          return;
+        }
+      }
+      // ネットワーク不達もしくはサーバエラー
+      toast.error('Notion連携の開始に失敗しました');
+    },
+  });
+
+  const disconnect = useMutation({
+    mutationFn: () => apiClient('/integrations/notion', 'DELETE'),
+
+    onSuccess: () => {
+      // 未連携に変わったので状態を再取得しボタンを切り替える
+      queryClient.invalidateQueries({ queryKey: NOTION_STATUS_QUERY_KEY });
+      toast.success('Notion連携を解除しました');
+    },
+
+    onError: (err) => {
       if (
         err instanceof HttpError &&
         err.statusCode === HttpStatus.UNAUTHORIZED
@@ -37,9 +67,9 @@ export const useNotionAuth = (deckId: string) => {
         return;
       }
       // ネットワーク不達もしくはサーバエラー
-      toast.error('Notion連携の開始に失敗しました');
+      toast.error('Notion連携の解除に失敗しました');
     },
   });
 
-  return { connect };
+  return { connect, disconnect };
 };

--- a/frontend/features/integration/notion/hooks/useNotionStatus.ts
+++ b/frontend/features/integration/notion/hooks/useNotionStatus.ts
@@ -1,0 +1,23 @@
+import { apiClient } from '@/lib/api/client';
+import { useQuery } from '@tanstack/react-query';
+import { components } from '@memo-anki/shared';
+
+type NotionStatus = components['schemas']['NotionStatusResponse'];
+
+/** Notion連携状態のクエリキー（連携/解除後の再取得に使う） */
+export const NOTION_STATUS_QUERY_KEY = ['notion', 'status'] as const;
+
+/**
+ * Notion連携状態取得フック
+ *
+ * 連携ボタンの出し分けに使う。
+ * - connected=false → 連携ボタンのみ表示
+ * - connected=true  → 連携解除ボタン＋インポートボタンを表示
+ */
+export const useNotionStatus = () => {
+  return useQuery<NotionStatus>({
+    queryKey: NOTION_STATUS_QUERY_KEY,
+    queryFn: () =>
+      apiClient('/integrations/notion/status', 'GET') as Promise<NotionStatus>,
+  });
+};

--- a/frontend/features/integration/notion/hooks/useNotionUrlResponse.ts
+++ b/frontend/features/integration/notion/hooks/useNotionUrlResponse.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { toast } from 'sonner';
+
+/**
+ * Notion リダイレクト結果フック（URLパラメータ形式）
+ *
+ * Notion OAuth コールバック後、バックエンドは
+ * `/decks/{deckId}?integration=<code>` へリダイレクトする。
+ * このフックはその `integration` パラメータを読み取り、トーストで結果を伝える。
+ */
+export const useNotionUrlResponse = (deckId: string) => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  useEffect(() => {
+    const result = searchParams.get('integration');
+    if (!result) return;
+
+    switch (result) {
+      case 'notion_success':
+        toast.success('Notionと連携しました');
+        break;
+      case 'notion_cancelled':
+        toast.error('Notion連携をキャンセルしました');
+        break;
+      case 'notion_invalid':
+        // クライアント起因の失敗。フロントは「失敗しました」だけ伝える。
+        toast.error('Notion連携に失敗しました');
+        break;
+      case 'notion_failed':
+        // Notion/内部起因の失敗。予期しないエラーとして伝える。
+        toast.error('予期しないエラーが発生しました');
+        break;
+    }
+
+    // パラメータを除去（リロード時のトースト再表示防止）
+    router.replace(`/decks/${deckId}`);
+  }, [searchParams, router, deckId]);
+};


### PR DESCRIPTION
## 概要
画面のNotion連携・解除・インポートボタンを作成した。

## 詳細
- 連携と削除ボタンの入れ替えロジック作成
- インポートボタンの作成
- リダイレクト時のトースト表示ロジックを作成

例外の通知管理に関してはバックエンドからリダイレクトまたは、json形式で返却されるので、リダイレクトはurlのパラメータを読み取って判断。json形式は、メッセージをそのままトーストに送る。APIResponseErrorの場合は、sdkcodeによる分岐でメッセージのだし分けを行う。

テストは最後におこなう。次はインポートモーダルの作成

---
Closes #152 