### PR TITLE
Test/notion view

### DIFF
--- a/frontend/features/integration/notion/components/NotionImportModal.test.tsx
+++ b/frontend/features/integration/notion/components/NotionImportModal.test.tsx
@@ -1,0 +1,166 @@
+// インポートモーダルの結合試験(Step遷移に伴う副作用のうち、フック単体では担保できないものに限定)
+// ・import の二重実行防止(実行回数) ・失敗時の踏みとどまり(閉じない/壊さない) ・DB選び直し時の選択リセット(誤カラム送信防止)
+// API引数・cards無効化・完了トースト自体は useNotionImport.test.ts で担保済み。UIの見た目は対象外。
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+import { apiClient } from '@/lib/api/client';
+import { toast } from 'sonner';
+import { HttpError } from '@/lib/api/httpError';
+import NotionImportModal from './NotionImportModal';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: vi.fn(),
+}));
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const DATABASES = {
+  databases: [
+    { id: 'db-1', title: '学習メモ' },
+    { id: 'db-2', title: '読書ログ' },
+  ],
+};
+const COLUMNS = {
+  databaseId: 'db-1',
+  databaseTitle: '学習メモ',
+  columns: [
+    { name: 'Content', type: 'rich_text' },
+    { name: 'Tags', type: 'select' },
+    { name: 'Name', type: 'title' },
+  ],
+};
+
+// apiClientをパス/メソッドで振り分ける。失敗/保留させたい呼び出しはオプションで指定する。
+type FailOpts = { failImport?: boolean; hangImport?: boolean };
+const setupApi = (opts: FailOpts = {}) => {
+  vi.mocked(apiClient).mockImplementation((path: string) => {
+    if (path === '/integrations/notion/databases') {
+      return Promise.resolve(DATABASES);
+    }
+    if (path.endsWith('/columns')) {
+      return Promise.resolve(COLUMNS);
+    }
+    if (path.endsWith('/import')) {
+      if (opts.hangImport) return new Promise(() => {}); // 解決しない(importing状態を保持)
+      if (opts.failImport) return Promise.reject(new HttpError(500, 'imp'));
+      return Promise.resolve({ count: 3 });
+    }
+    return Promise.reject(new Error(`unexpected ${path}`));
+  });
+};
+
+const onClose = vi.fn();
+
+// 各テストで新しい QueryClient を使う (キャッシュ汚染を避ける)
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, invalidateSpy };
+};
+
+const renderModal = (open = true) => {
+  const { Wrapper, invalidateSpy } = createWrapper();
+  render(<NotionImportModal open={open} deckId="deck-1" onClose={onClose} />, {
+    wrapper: Wrapper,
+  });
+  return { invalidateSpy };
+};
+
+// import POST の呼び出し回数(=実行回数)
+const importCallCount = () =>
+  vi
+    .mocked(apiClient)
+    .mock.calls.filter((c) => String(c[0]).endsWith('/import')).length;
+
+// 確認画面まで進める共通操作
+const advanceToConfirm = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(await screen.findByRole('button', { name: '学習メモ' }));
+  await user.click(screen.getByRole('button', { name: '次へ' }));
+  // カラムボタンの名前は「カラム名 + 型」が結合される(例: "Content rich_text")
+  await user.click(await screen.findByRole('button', { name: /Content/ }));
+  await user.click(screen.getByRole('button', { name: '次へ' }));
+  await screen.findByRole('button', { name: 'インポート' });
+};
+
+beforeEach(() => {
+  vi.mocked(apiClient).mockReset();
+  vi.mocked(toast.success).mockReset();
+  vi.mocked(toast.error).mockReset();
+  onClose.mockReset();
+});
+
+describe('NotionImportModal - 二重実行防止', () => {
+  it('インポート中はインポートボタンが消え、import POSTは1回しか呼ばれない', async () => {
+    const user = userEvent.setup();
+    setupApi({ hangImport: true }); // importを保留してimporting状態を維持
+    renderModal();
+
+    await advanceToConfirm(user);
+    await user.click(screen.getByRole('button', { name: 'インポート' }));
+
+    // importing表示に切り替わり、インポートボタンは存在しない(再発火不可)
+    expect(await screen.findByText('インポート中...')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'インポート' }),
+    ).not.toBeInTheDocument();
+    expect(importCallCount()).toBe(1);
+  });
+});
+
+describe('NotionImportModal - 失敗時の踏みとどまり/復帰', () => {
+  it('インポート失敗時は確認画面に戻り、onCloseもcards無効化も起きない', async () => {
+    const user = userEvent.setup();
+    setupApi({ failImport: true });
+    const { invalidateSpy } = renderModal();
+
+    await advanceToConfirm(user);
+    await user.click(screen.getByRole('button', { name: 'インポート' }));
+
+    // エラートーストが出る
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    // 確認画面に戻る(再試行可能)
+    expect(
+      await screen.findByRole('button', { name: 'インポート' }),
+    ).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: ['cards'],
+      exact: false,
+    });
+  });
+});
+
+describe('NotionImportModal - 選択リセット', () => {
+  it('DBを選び直すと前回のカラム選択は引き継がれない', async () => {
+    const user = userEvent.setup();
+    setupApi();
+    renderModal();
+
+    // 1周目: 学習メモ→Content選択→確認
+    await advanceToConfirm(user);
+    expect(screen.getByText('Content')).toBeInTheDocument();
+
+    // 確認→カラム→DB選択へ戻る
+    await user.click(screen.getByRole('button', { name: '戻る' })); // confirm→column
+    await user.click(screen.getByRole('button', { name: '戻る' })); // column→db
+
+    // 別DBを選んで次へ
+    await user.click(screen.getByRole('button', { name: '読書ログ' }));
+    await user.click(screen.getByRole('button', { name: '次へ' }));
+
+    // カラム選択画面: selectedColumnがリセットされ「次へ」がdisabled
+    const nextBtn = await screen.findByRole('button', { name: '次へ' });
+    expect(nextBtn).toBeDisabled();
+  });
+});

--- a/frontend/features/integration/notion/hooks/useNotionAuth.test.ts
+++ b/frontend/features/integration/notion/hooks/useNotionAuth.test.ts
@@ -1,0 +1,166 @@
+// Notion連携ボタンの副作用の単体試験(connectのwindow.location遷移 / disconnectのstatus無効化 / トースト出し分け)
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+import { apiClient } from '@/lib/api/client';
+import { toast } from 'sonner';
+import { HttpError } from '@/lib/api/httpError';
+import { useNotionAuth } from './useNotionAuth';
+import { NOTION_STATUS_QUERY_KEY } from './useNotionStatus';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: vi.fn(),
+}));
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, invalidateSpy };
+};
+
+// window.location.href への代入(画面全体遷移)を観測するためモックに差し替える
+const originalLocation = window.location;
+beforeEach(() => {
+  vi.mocked(apiClient).mockReset();
+  vi.mocked(toast.success).mockReset();
+  vi.mocked(toast.error).mockReset();
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: { href: '' },
+  });
+});
+afterEach(() => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: originalLocation,
+  });
+});
+
+// connect 連携開始
+describe('useNotionAuth - connect(連携開始)', () => {
+  it('成功時に /auth を叩き、返却URLへ window.location で遷移する', async () => {
+    vi.mocked(apiClient).mockResolvedValueOnce({
+      url: 'https://api.notion.com/authorize?x=1',
+    });
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useNotionAuth('deck-1'), {
+      wrapper: Wrapper,
+    });
+
+    result.current.connect.mutate();
+
+    await waitFor(() => expect(result.current.connect.isSuccess).toBe(true));
+
+    expect(apiClient).toHaveBeenCalledWith(
+      '/integrations/notion/auth?deckId=deck-1',
+      'GET',
+    );
+    // 画面全体遷移が起きること
+    expect(window.location.href).toBe('https://api.notion.com/authorize?x=1');
+  });
+
+  it('401のとき再ログインを促し、遷移しない', async () => {
+    vi.mocked(apiClient).mockRejectedValueOnce(
+      new HttpError(401, 'unauthorized'),
+    );
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useNotionAuth('deck-1'), {
+      wrapper: Wrapper,
+    });
+
+    result.current.connect.mutate();
+
+    await waitFor(() => expect(result.current.connect.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith('ログインし直してください');
+    expect(window.location.href).toBe('');
+  });
+
+  it('400のとき不正リクエストのトーストを出す', async () => {
+    vi.mocked(apiClient).mockRejectedValueOnce(new HttpError(400, 'bad'));
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useNotionAuth('deck-1'), {
+      wrapper: Wrapper,
+    });
+
+    result.current.connect.mutate();
+
+    await waitFor(() => expect(result.current.connect.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith('不正なリクエストです。');
+  });
+
+  it('その他/非HttpErrorのとき汎用エラートーストを出す', async () => {
+    vi.mocked(apiClient).mockRejectedValueOnce(new Error('NetworkError'));
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useNotionAuth('deck-1'), {
+      wrapper: Wrapper,
+    });
+
+    result.current.connect.mutate();
+
+    await waitFor(() => expect(result.current.connect.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith('Notion連携の開始に失敗しました');
+  });
+});
+
+// disconnect 連携解除
+describe('useNotionAuth - disconnect(連携解除)', () => {
+  it('成功時に DELETE し、連携状態を無効化して成功トーストを出す', async () => {
+    vi.mocked(apiClient).mockResolvedValueOnce(null);
+    const { Wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useNotionAuth('deck-1'), {
+      wrapper: Wrapper,
+    });
+
+    result.current.disconnect.mutate();
+
+    await waitFor(() => expect(result.current.disconnect.isSuccess).toBe(true));
+
+    expect(apiClient).toHaveBeenCalledWith('/integrations/notion', 'DELETE');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: NOTION_STATUS_QUERY_KEY,
+    });
+    expect(toast.success).toHaveBeenCalledWith('Notion連携を解除しました');
+  });
+
+  it('401のとき再ログインを促し、status は無効化しない', async () => {
+    vi.mocked(apiClient).mockRejectedValueOnce(
+      new HttpError(401, 'unauthorized'),
+    );
+    const { Wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useNotionAuth('deck-1'), {
+      wrapper: Wrapper,
+    });
+
+    result.current.disconnect.mutate();
+
+    await waitFor(() => expect(result.current.disconnect.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith('ログインし直してください');
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('その他のとき汎用エラートーストを出す', async () => {
+    vi.mocked(apiClient).mockRejectedValueOnce(new HttpError(500, 'server'));
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useNotionAuth('deck-1'), {
+      wrapper: Wrapper,
+    });
+
+    result.current.disconnect.mutate();
+
+    await waitFor(() => expect(result.current.disconnect.isError).toBe(true));
+    expect(toast.error).toHaveBeenCalledWith('Notion連携の解除に失敗しました');
+  });
+});

--- a/frontend/features/integration/notion/hooks/useNotionErrorHandler.test.ts
+++ b/frontend/features/integration/notion/hooks/useNotionErrorHandler.test.ts
@@ -1,0 +1,79 @@
+// Notion系API共通エラーハンドラの単体試験(分岐網羅: 再連携要求 / メッセージ / 汎用)
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+import { toast } from 'sonner';
+import { HttpError } from '@/lib/api/httpError';
+import {
+  useNotionErrorHandler,
+  NOTION_REAUTH_REQUIRED_CODE,
+} from './useNotionErrorHandler';
+import { NOTION_STATUS_QUERY_KEY } from './useNotionStatus';
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// QueryClientを毎回新規に作り、invalidateQueriesの呼び出しを監視する
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, invalidateSpy };
+};
+
+beforeEach(() => {
+  vi.mocked(toast.success).mockReset();
+  vi.mocked(toast.error).mockReset();
+});
+
+describe('useNotionErrorHandler', () => {
+  it('再連携要求(NOTION_REAUTH_REQUIRED)のとき連携状態を無効化しメッセージを表示する', () => {
+    const { Wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useNotionErrorHandler(), {
+      wrapper: Wrapper,
+    });
+
+    result.current(
+      new HttpError(403, '再連携が必要です', NOTION_REAUTH_REQUIRED_CODE),
+    );
+
+    // 連携状態(status)が再取得されること
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: NOTION_STATUS_QUERY_KEY,
+    });
+    // バックエンドのメッセージをそのまま表示する
+    expect(toast.error).toHaveBeenCalledWith('再連携が必要です');
+  });
+
+  it('HttpError(再連携要求以外)のとき status は無効化せずメッセージをそのまま表示する', () => {
+    const { Wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useNotionErrorHandler(), {
+      wrapper: Wrapper,
+    });
+
+    result.current(new HttpError(404, 'データベースが見つかりません'));
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith('データベースが見つかりません');
+  });
+
+  it('HttpError以外(通信断等)のとき汎用メッセージを表示する', () => {
+    const { Wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useNotionErrorHandler(), {
+      wrapper: Wrapper,
+    });
+
+    result.current(new Error('NetworkError'));
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith('通信に失敗しました');
+  });
+});

--- a/frontend/features/integration/notion/hooks/useNotionImport.test.ts
+++ b/frontend/features/integration/notion/hooks/useNotionImport.test.ts
@@ -1,0 +1,91 @@
+// Notionインポート実行フックの単体試験(POST引数 / 成功時のcards無効化・完了トースト / エラー委譲)
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+import { apiClient } from '@/lib/api/client';
+import { toast } from 'sonner';
+import { HttpError } from '@/lib/api/httpError';
+import { useNotionImport } from './useNotionImport';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: vi.fn(),
+}));
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// 各テストで新しい QueryClient を作る (キャッシュ汚染を避ける)
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, invalidateSpy };
+};
+
+beforeEach(() => {
+  vi.mocked(apiClient).mockReset();
+  vi.mocked(toast.success).mockReset();
+  vi.mocked(toast.error).mockReset();
+});
+
+describe('useNotionImport', () => {
+  it('成功時に import POST を正しい引数で叩き、cards を無効化し完了トーストを出す', async () => {
+    vi.mocked(apiClient).mockResolvedValueOnce({ count: 3 });
+    const { Wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useNotionImport(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate({
+      databaseId: 'db 1', // encode 確認のため空白を含める
+      deckId: 'deck-1',
+      columnName: 'Content',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // databaseId が URL エンコードされ、body は deckId/columnName のみ
+    expect(apiClient).toHaveBeenCalledWith(
+      '/integrations/notion/databases/db%201/import',
+      'POST',
+      { deckId: 'deck-1', columnName: 'Content' },
+    );
+    // 取り込んだカードを一覧へ反映
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['cards'],
+      exact: false,
+    });
+    expect(toast.success).toHaveBeenCalledWith('インポートが完了しました');
+  });
+
+  it('失敗時は共通エラーハンドラに委譲し、cards 無効化も完了トーストも起きない', async () => {
+    vi.mocked(apiClient).mockRejectedValueOnce(new HttpError(500, 'imp'));
+    const { Wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useNotionImport(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.mutate({
+      databaseId: 'db-1',
+      deckId: 'deck-1',
+      columnName: 'Content',
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    // 共通ハンドラ(useNotionErrorHandler)経由でエラートーストが出る
+    expect(toast.error).toHaveBeenCalledWith('imp');
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: ['cards'],
+      exact: false,
+    });
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要
Notion連携フロントエンドのテストを追加。見た目は検証せず、壊れると実害が出る副作用に絞って確認する。ロジックはフック側で単体検証し、フックでは担保できない「画面をまたいだ挙動」だけをモーダルの結合試験で確認する方針。

## 詳細
単体3本（共通エラーハンドラ / 連携ボタン / インポート実行）と結合1本（モーダルのStep遷移に伴う副作用）

1. useNotionErrorHandler.test.ts（単体）
Notion系API共通のエラー処理を検証。エラーの種類で挙動が分かれるので、その分岐を網羅する。

2. useNotionAuth.test.ts（単体）
連携ボタン（開始 / 解除）の副作用を検証。
- 連携開始・成功 → 認証URLへ画面遷移（window.location）する
- 連携解除・成功 → 連携状態を無効化し、完了トーストを出す

各エラーでは状況に応じたトーストを出し、成功時の副作用は起こさない

3. useNotionImport.test.ts（単体）
Cardへのインポート実行そのものを検証。
- 成功 → 正しいURL・引数でPOSTし、カード
- 失敗 → 共通エラーハンドラに任せ、一覧更新も完了トーストも起こさない

4. NotionImportModal.test.tsx（結合）
DB選択→カラム選択→確認→実行というStep全体を通し、フック単体では確認できない副作用だけを検証。

---
Closes #157 