### PR TITLE
Fix/deploy samesite setting

### DIFF
--- a/backend/src/integrations/notion/oauth/notion-oauth.controller.ts
+++ b/backend/src/integrations/notion/oauth/notion-oauth.controller.ts
@@ -55,10 +55,13 @@ export class NotionOAuthController {
     // CSRF対策のランダムstateを生成
     const state = this.notionOAuthService.generateState();
 
+    // 本番はフロント(別サイト)からのクロスサイトfetchで発行するため none 必須。
+    // lax だとクロスサイトfetch応答のSet-Cookieが保存されず、callbackでCookieが欠落する。
+    const isProd = process.env.NODE_ENV === 'production';
     const cookieOptions: express.CookieOptions = {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production', // Secure: 本番のみ
-      sameSite: 'lax',
+      secure: isProd, // Secure: 本番のみ
+      sameSite: isProd ? 'none' : 'lax',
       path: '/',
       maxAge: COOKIE_MAX_AGE, // 5分
     };

--- a/backend/src/integrations/notion/oauth/notion-oauth.cookies.ts
+++ b/backend/src/integrations/notion/oauth/notion-oauth.cookies.ts
@@ -16,10 +16,12 @@ export const COOKIE_MAX_AGE = 5 * 60 * 1000;
  * callback成功・失敗のいずれでも実行する（再利用防止のため）
  */
 export function clearOAuthCookies(res: express.Response) {
+  // 発行時(startAuth)と同じ属性でないとブラウザはCookieを削除できない。
+  const isProd = process.env.NODE_ENV === 'production';
   const clearOptions: express.CookieOptions = {
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
+    secure: isProd,
+    sameSite: isProd ? 'none' : 'lax',
     path: '/',
   };
   res.clearCookie(COOKIE_OAUTH_STATE, clearOptions);

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -58,13 +58,31 @@ async function toHttpError(res: Response): Promise<HttpError> {
   return new HttpError(res.status, message, body?.code);
 }
 
+/**
+ * 進行中のリフレッシュを共有するためのPromise。
+ * 複数リクエストが同時に401になっても/auth/refreshを1回に集約する。
+ * RTは単回使用（呼ぶたびにローテーション）のため、並列に投げると
+ * 後発リクエストが古いRTで401になる。それを防ぐ。
+ */
+let refreshPromise: Promise<string> | null = null;
+
 /** リフレッシュ処理 RTを用いてATを取得する */
 export async function refreshAccessToken(): Promise<string> {
-  const res = await fetchOnce('/auth/refresh', 'POST', undefined, null);
+  // 既に進行中ならそれを待つ（重複リフレッシュ＝RT競合の防止）
+  if (refreshPromise) return refreshPromise;
 
-  if (!res.ok) throw await toHttpError(res);
+  refreshPromise = (async () => {
+    const res = await fetchOnce('/auth/refresh', 'POST', undefined, null);
 
-  const data = (await res.json()) as { accessToken: string };
-  useAuthStore.getState().setAccessToken(data.accessToken);
-  return data.accessToken;
+    if (!res.ok) throw await toHttpError(res);
+
+    const data = (await res.json()) as { accessToken: string };
+    useAuthStore.getState().setAccessToken(data.accessToken);
+    return data.accessToken;
+  })().finally(() => {
+    // 成否に関わらず次回のために解放する
+    refreshPromise = null;
+  });
+
+  return refreshPromise;
 }


### PR DESCRIPTION
## 概要

本番で Notion 連携後にカード一覧やデッキ名が表示されず、/card と notion/status が 401 になる不具合を修正した。原因は2つ。

1. Notion連携(OAuth)が本番で毎回失敗していた。
認可に使う一時 Cookie が本番で保存されず、callback で検証に失敗していた。
2. 連携から戻った直後にカード/デッキが 401 — 複数 API が同時にトークン更新を呼び、更新用トークンの取り合いで片方が弾かれていた。

## 詳細

① OAuth用Cookieが本番で保存されない問題

Notion 認可に使う一時 Cookieが SameSite=Lax 固定だった。
これらはフロントからバックへの別サイト間 fetch のレスポンスで発行されるが、SameSite=Lax の Cookie は別サイト間 fetch 経由ではブラウザに保存されず。結果、callback 時に Cookie が無く、連携が notion_invalid で失敗していた。

→ ログイン用トークンと同様に、本番のみ SameSite=None; Secure に変更。

② 同時リフレッシュによる401問題

連携から戻るとアクセストークン（メモリ保持）が消え、card と status が同時に refresh を呼ぶことがあった。
同時に2本来ると先勝ちでRTが更新され、後発のリクエストが古いRTで 401 になってしまう。

→ フロント側で進行中のリフレッシュを1つの処理にまとめ、同時に来た 401 はすべて同じ更新結果を待つようにした。

### 動作確認・注意点
・CSRF耐性が下がる
Lax は「別サイトからの送信」を制限することでCSRF対策になっていた。None は全コンテキストで送信されるため、その防御が外れる。
ただし今回のケースではcookieの設定が HttpOnly でJSから読めないので実害は小さい。